### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ __pycache__
 .DS_Store
 src/.DS_Store
 
+# Client
+/client/AdminUI/node_modules
+/client/AdminUI/node_modules/*
+/client/AdminUI/dist
 
 # Controller
 controller/.env
@@ -23,9 +27,6 @@ gophish/.env
 /controller/src/celerybeat-schedule
 /controller/src/celerybeat.pid
 /controller/src/tasks/logs/celery.log
-/controller/CPAAdmin/CPAAdmin/AdminUI/node_modules
-/controller/CPAAdmin/CPAAdmin/AdminUI/node_modules/*
-/controller/CPAAdmin/CPAAdmin/AdminUI/dist
 
 # Python env
 env/

--- a/controller/etc/env.dist
+++ b/controller/etc/env.dist
@@ -1,6 +1,3 @@
-# Angular
-NODE_ENV=dev
-
 # Django
 SECRET_KEY=dbaa1_i7%*3r9-=z-+_mz4r-!qeed@(-a_r(g@k8jo8y3r27%m
 DEBUG=1

--- a/controller/src/tasks/logs/README.md
+++ b/controller/src/tasks/logs/README.md
@@ -1,0 +1,4 @@
+# Celery logs
+
+This is where celery logs will live at:
+- `celery.log`


### PR DESCRIPTION
This is a minor update to gitignore and added a readme to the tasks folder

## 🗣 Description
updated gitignore to reflect project restructuring. also added a readme file into the tasks folder which is required to exist for celery to save out logs to.

## 💭 Motivation and Context
project will error out without an empty tasks folder

## 🧪 Testing
ran the project locally

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
