### PR TITLE
feature: gophish campaign api endpoints

### DIFF
--- a/controller/etc/Dockerfile
+++ b/controller/etc/Dockerfile
@@ -21,5 +21,4 @@ RUN chmod a+x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # During debugging, this entry point will be overridden. For more information, refer to https://aka.ms/vscode-docker-python-debug
-# File wsgi.py was not found in subfolder:controller. Please enter the Python path to wsgi file.
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "pythonPath.to.wsgi"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "config.wsgi"]

--- a/controller/etc/env.dist
+++ b/controller/etc/env.dist
@@ -1,6 +1,3 @@
-# Angular
-NODE_ENV=dev
-
 # Django
 SECRET_KEY=dbaa1_i7%*3r9-=z-+_mz4r-!qeed@(-a_r(g@k8jo8y3r27%m
 DEBUG=1

--- a/controller/src/api/serializers.py
+++ b/controller/src/api/serializers.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from rest_framework import serializers
 
-from .utils import Subscription
 
 class SubscriptionSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=200)
@@ -12,13 +11,4 @@ class SubscriptionSerializer(serializers.Serializer):
     last_action = serializers.DateField()
     active = serializers.BooleanField
 
-    def create(self, validated_data):
-        subscription = Subscription(
-            name=validated_data.get('name'),
-            status=validated_data.get('status'),
-            primary_contact=validated_data.get('primary_contact'),
-            customer=validated_data.get('customer'),
-            last_action=validated_data.get('last_action'),
-            active=validated_data.get('active')
-        )
         return subscription

--- a/controller/src/api/urls.py
+++ b/controller/src/api/urls.py
@@ -4,7 +4,7 @@ API URLs.
 This lists all urls under the API app.
 """
 # Third-Party Libraries
-from api.views import subscription_views, target_views, template_views
+from api.views import subscription_views, target_views, template_views, campaign_views
 from django.urls import path
 
 urlpatterns = [
@@ -33,5 +33,13 @@ urlpatterns = [
         "v1/target/<target_uuid>/",
         target_views.TargetView.as_view(),
         name="target_get_api",
+    ),
+    path(
+        "v1/campaigns/", campaign_views.CampaignListView.as_view(), name="campaign_list"
+    ),
+    path(
+        "v1/campaign/<campaign_id>/",
+        campaign_views.CampaignView.as_view(),
+        name="campaign_detail",
     ),
 ]

--- a/controller/src/api/views/campaign_views.py
+++ b/controller/src/api/views/campaign_views.py
@@ -1,0 +1,54 @@
+import logging
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.manager import CampaignManager
+
+
+logger = logging.getLogger(__name__)
+manager = CampaignManager()
+
+
+class CampaignListView(APIView):
+    """
+    This is the a Campaign list API View.
+
+    This handles the API to get a List of GoPhish Campaigns.
+    """
+
+    def get(self, request):
+        campaigns = manager.get("campaign")
+        context = {
+            campaign.id: {
+                "name": campaign.name,
+                "created date": campaign.created_date,
+                "send by date": campaign.send_by_date,
+                "launch date": campaign.launch_date,
+                "status": campaign.status,
+            }
+            for campaign in campaigns
+        }
+        return Response(context)
+
+
+class CampaignView(APIView):
+    """
+    This is the Campaign Detail APIView.
+
+    This handles the API to get Campaign details with campaign_id from GoPhish.
+    """
+
+    def get(self, request, campaign_id):
+        campaign = manager.get("campaign", campaign_id=campaign_id)
+
+        context = {
+            "id": campaign.id,
+            "name": campaign.name,
+            "created date": campaign.created_date,
+            "launch date": campaign.launch_date,
+            "status": campaign.status,
+        }
+
+        return Response(context)


### PR DESCRIPTION
added two api endpoints for fetching a list of gophish campaigns and viewing campaign details

## 🗣 Description
created two new endpoints that can be accessed at:
localhost:8000/v1/api/campaigns/
localhost:8000/v1/api/campaign/<campaign_id>/

Also cleaned up some minor code clean up including hiding npm warnings

## 💭 Motivation and Context

pull gophish data through controller api endpoints

## 🧪 Testing

successfully tested the endpoints locally pulling existing campaign data

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
