### PR TITLE
fix: subscription view

### DIFF
--- a/controller/src/api/views/subscription_views.py
+++ b/controller/src/api/views/subscription_views.py
@@ -51,12 +51,16 @@ class SubscriptionsListView(APIView):
         templates = manager.get("email_template")
 
         # Create a User Group
+        existing_group_names = [group.name for group in manager.get("user_group")]
         group_name = f"{last_name}'s Targets"
         target_list = post_data.get("target_email_list")
 
-        target = manager.create(
-            "user_group", group_name=group_name, target_list=target_list
-        )
+        if not group_name in existing_group_names:
+            target = manager.create(
+                "user_group", group_name=group_name, target_list=target_list
+            )
+        else:
+            target = manager.get("user_group")[0]
 
         # Create a GoPhish Campaigns
         for template in templates:


### PR DESCRIPTION
subscription create view will fail if a user group is already created

## 🗣 Description

quick fix to resolve issue when a user group is already created

## 💭 Motivation and Context

## 🧪 Testing

successfully ran it a few times locally 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
