### PR TITLE
Templates page created, deception calc moved to templates manage page

### DIFF
--- a/client/AdminUI/src/app/app.module.ts
+++ b/client/AdminUI/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AngularEditorModule } from '@kolkov/angular-editor';
 import { MaterialModule } from './material.module';
+import { MatSortModule } from '@angular/material/sort'
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -61,6 +62,7 @@ import { UserAdminComponent } from './components/user-admin/user-admin.component
     AppRoutingModule,
     BrowserAnimationsModule,
     MaterialModule,
+    MatSortModule,
     FormsModule,
     ReactiveFormsModule,
     AutosizeModule,
@@ -73,6 +75,9 @@ import { UserAdminComponent } from './components/user-admin/user-admin.component
     ThemeService,
     LayoutMainService,
     HttpClient
+  ],
+  exports: [
+    MatSortModule
   ],
   bootstrap: [AppComponent]
 })

--- a/client/AdminUI/src/app/components/layout/layout-main/layout-main.component.html
+++ b/client/AdminUI/src/app/components/layout/layout-main/layout-main.component.html
@@ -18,14 +18,12 @@
       yPosition="below"
       class="mat-menu-custom-header"
     >
+    
       <button mat-menu-item routerLink="/subscription">Subscriptions</button>
-      <button mat-menu-item routerLink="/templatemanager">Templates</button>
+      <button mat-menu-item routerLink="/templatespage">Templates</button>
       <button mat-menu-item routerLink="/contacts">Contacts</button>
       <button mat-menu-item routerLink="/domains">Domains</button>
       <button mat-menu-item routerLink="/organizations">Organizations</button>
-      <button mat-menu-item routerLink="/deceptioncalculator">
-        Deception Calculator
-      </button>
       <button mat-menu-item routerLink="/useradmin">User Admin</button>
     </mat-menu>
     <span class="fill-remaining-space"></span>

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid" [style.height.px]="body_content_height">
   <div class="row h-100">
-    <div class="col-4 border-right h-100 p-3 flex-container flex-column">
+    <!-- <div class="col-4 border-right h-100 p-3 flex-container flex-column">
       <mat-form-field class="w-100 pb-3" appearance="outline">
         <mat-label>Search</mat-label>
         <input [(ngModel)]="search_input" matInput />
@@ -24,17 +24,17 @@
           </button>
         </mat-list-item>
       </mat-list>
-    </div>
+    </div> -->
     <div
-      class="col-8 h-100 d-flex flex-column"
+      class="col-8 h-100 d-flex flex-column mt-2"
       [formGroup]="currentTemplateFormGroup"
     >
       <div
         #selectedTemplateTitle
-        class="flex-container flex-row p-3 selected-template"
+        class="flex-container flex-row selected-template"
       >
         <mat-form-field
-          class="w-100 mr-3 selected_template_title"
+          class="w-100 selected_template_title"
           appearance="outline"
         >
           <mat-label>Template Name</mat-label>
@@ -54,7 +54,7 @@
             Template name <strong>required</strong>
           </mat-error>
         </mat-form-field>
-        <button
+        <!-- <button
           [disabled]="
             currentTemplateFormGroup.controls.templateUUID.value == null
           "
@@ -66,7 +66,7 @@
           color="primary"
         >
           Deception Calculator
-        </button>
+        </button> -->
       </div>
       <div class="d-flex">
         <mat-tab-group
@@ -223,7 +223,7 @@
       </div>
 
       <div class="flex-container flex-row save_container pb-3">
-        <button
+        <!-- <button
           id="save-button"
           class="d-flex"
           mat-raised-button
@@ -231,14 +231,14 @@
           (click)="setEmptyTemplateForm()"
         >
           New Template
-        </button>
+        </button> -->
         <button
           id="save-button"
           class="d-flex"
           mat-raised-button
           color="warn"
           (click)="deleteTemplate()"
-          [disabled]=!templateId
+          *ngIf=templateId
         >
         Delete Template
       </button>
@@ -248,9 +248,89 @@
           mat-raised-button
           color="primary"
           (click)="saveTemplate()"        >
-          {{templateId ? 'Update' : 'Save New'}}
+          Save Template
         </button>
       </div>
     </div>
+    <div class="col-4 h-100 testing border-left " 
+    [formGroup]="currentTemplateFormGroup">
+      <h2>Deception Calculations</h2>
+      <div class="d-flex flex-column overflow-auto deception_calc_content ">
+        <div class="">
+          <mat-label class="mb-3">Apperance & Grammar</mat-label>
+          <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="grammar">
+              <mat-radio-button [value]=0 radioGroup="grammarRadioGroup">0 = Poor</mat-radio-button>
+              <mat-radio-button [value]=1 radioGroup="grammarRadioGroup">1 = Decent</mat-radio-button>
+              <mat-radio-button [value]=2 radioGroup="grammarRadioGroup">2 = Proper</mat-radio-button>
+          </mat-radio-group>
+      </div>
+        <div class="" >
+            <mat-label class="mb-3">Link Domain</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="link_domain">
+                <mat-radio-button [value]=0 radioGroup="linkRadioGroup">0 = Fake</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="linkRadioGroup">1 = Spoofed / Hidden</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="" >
+            <mat-label class="mb-3">Logo / Graphics</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="logo_graphics">
+                <mat-radio-button [value]=0 radioGroup="graphicsRadioGroup">0 = Fake / None</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="graphicsRadioGroup">1 = Spoofed / HTML</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="" >
+            <mat-label class="mb-3">Sender External</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="external">
+                <mat-radio-button [value]=0 radioGroup="senderExternalRadioGroup">0 = Fake / NA</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="senderExternalRadioGroup">1 = Spoofed</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="" >
+            <mat-label class="mb-3">Internal</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="internal">
+                <mat-radio-button [value]=0 radioGroup="internalRadioGroup">0 = Fake / NA</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="internalRadioGroup">1 = Unknown Spoofed</mat-radio-button>
+                <mat-radio-button [value]=2 radioGroup="internalRadioGroup">2 = Known Spoofed</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="" >
+            <mat-label class="mb-3">Authoritative</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="authoritative">
+                <mat-radio-button [value]=0 radioGroup="authoritativeRadioGroup">0 = None</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="authoritativeRadioGroup">1 = Corprate / Local</mat-radio-button>
+                <mat-radio-button [value]=2 radioGroup="authoritativeRadioGroup">2 = Federal / State</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="" >
+            <mat-label class="mb-3">Relevancy Organization</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="organization">
+                <mat-radio-button [value]=0 radioGroup="relevancyOrganizationGroup">0 = No</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="relevancyOrganizationGroup">1 = Yes</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="" >
+            <mat-label class="mb-3">Public News</mat-label>
+            <mat-radio-group appearance="outline" class="row radio_selection_group"  formControlName="public_news">
+                <mat-radio-button [value]=0 radioGroup="publicNewsGroup">0 = No</mat-radio-button>
+                <mat-radio-button [value]=1 radioGroup="publicNewsGroup">1 = Yes</mat-radio-button>
+            </mat-radio-group>
+        </div>
+        <div class="check-box-wrapper">
+          <mat-label class="mb-3">Behavior</mat-label>
+            <div class="deception_checkboxes mt-2 ml-3" >
+                <mat-checkbox formControlName="fear">Fear </mat-checkbox>
+                <mat-checkbox formControlName="curiosity">Duty or Obligation</mat-checkbox>
+                <mat-checkbox formControlName="duty_obligation">Curiosity</mat-checkbox>
+                <mat-checkbox formControlName="greed">Greed</mat-checkbox>
+            </div>
+        </div>
+        <div class="d-flex flex-row">
+          <mat-form-field appearance="outline" class="flex-grow-1" >
+              <mat-label>Final Deception Score</mat-label>
+              <input type="text" matInput placeholder="DeceptionScore" formControlName="final_deception_score">
+          </mat-form-field>
+       </div>
+        
+
   </div>
 </div>

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.scss
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.scss
@@ -25,3 +25,53 @@
   align-items: flex-end;
   flex: auto;
 }
+
+.deception_calc_content {
+  height: calc(100% - 48px)
+}
+
+.radio_selection {
+  width: 100%;
+  padding-left: 2em;
+}
+
+.radio_selection_group {
+  margin-left: 1em;
+  padding-top: .5em;
+}
+
+.radio_selection_group mat-radio-button {
+  width: 100%;
+}
+
+.check-box-wrapper {
+  display: inline-block;
+}
+
+.deception_checkboxes {
+  display: flex;
+  flex-direction: column;
+}
+
+// :root {
+//   --radio-button-size: 10px
+// }
+
+// :host ::ng-deep .mat-radio-container{
+//   height: var(--radio-button-size);
+//   width: 10px;
+// }
+// :host ::ng-deep .mat-radio-outer-circle{
+//   height: 10px;
+//   width: 10px;
+// }
+// :host ::ng-deep .mat-radio-inner-circle{
+//   height: 10px;
+//   width: 10px;
+// }
+// :host ::ng-deep .mat-radio-button .mat-radio-ripple{
+//   height: 20px; /*double of your required circle radius*/
+//   width: 20px;  /*double of your required circle radius*/
+//   left: calc(50% - 10px); /*'10px'-same as your required circle radius*/
+//   top: calc(50% - 10px); /*'10px'-same as your required circle radius*/
+// }

--- a/client/AdminUI/src/app/components/templates-page/templates-page.component.html
+++ b/client/AdminUI/src/app/components/templates-page/templates-page.component.html
@@ -1,5 +1,19 @@
-Welcome to the templates page!
-
-Glad you're here. Because that means it worked.
-<br><br><br>
-<button mat-raised-button color="primary" routerLink="/subscription" >Home</button>
+<div class="d-flex flex-column">
+  <div class="d-flex mb-2 w-100 search-content">
+      <mat-form-field class="flex-grow-1" appearance="outline">
+        <mat-label>Search</mat-label>
+          <input [(ngModel)]="search_input" (keyup)="filterTemplates($event.target.value)" matInput placeholder="Search" />
+      </mat-form-field>
+      <button mat-raised-button color="primary" class="flex-grow-0 mt-1 ml-2 " routerLink="/templatemanager" >Create New</button>
+  </div>
+  <div class="col p-0 w-100">    
+    <mat-table [dataSource]="templatesData" matSort>
+      <ng-container matColumnDef="name"><mat-header-cell *matHeaderCellDef mat-sort-header>Template Name</mat-header-cell>    <mat-cell *matCellDef="let row"> {{row.name}} </mat-cell></ng-container>
+      <ng-container matColumnDef="deception_score"><mat-header-cell *matHeaderCellDef mat-sort-header>Deception Score </mat-header-cell>    <mat-cell *matCellDef="let row"> {{row.deception_score }} </mat-cell></ng-container>
+      <ng-container matColumnDef="template_type"><mat-header-cell *matHeaderCellDef mat-sort-header>Type</mat-header-cell>    <mat-cell *matCellDef="let row"> {{row.template_type}} </mat-cell></ng-container>
+      <ng-container matColumnDef="created_by"><mat-header-cell *matHeaderCellDef mat-sort-header>Created By</mat-header-cell>    <mat-cell *matCellDef="let row"> {{row.created_by }} </mat-cell></ng-container>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row class="table-row" *matRowDef="let row; columns: displayedColumns" (click)="editTemplate(row)"></mat-row>
+  </mat-table>
+  </div>
+</div>

--- a/client/AdminUI/src/app/components/templates-page/templates-page.component.scss
+++ b/client/AdminUI/src/app/components/templates-page/templates-page.component.scss
@@ -1,0 +1,47 @@
+.testing {
+    outline: solid red 1px
+}.testing-2 {
+    outline: solid blue 1px
+}.testing-3 {
+    outline: solid green 1px
+}
+
+ .search-container .search-content {
+    display: flex;
+    flex-direction: row;
+ }
+
+mat-form-field.mat-form-field {
+    font-size: 12px;
+    
+}
+
+.search-content button.mat-raised-button {
+    font-size: 14px;
+    height: 42px;
+    margin-right: 0 !important //Over ride mat-button default
+}
+
+.mat-column-name {
+    word-wrap: break-word !important;
+    white-space: unset !important;
+    flex: 0 0 38% !important;
+    width: 48% !important;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  
+    word-break: break-word;
+  
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto;
+  }
+
+.table-row:hover{
+    border-bottom: solid 1px;
+    border-top: solid 1px;
+    
+}
+
+  

--- a/client/AdminUI/src/app/components/templates-page/templates-page.component.ts
+++ b/client/AdminUI/src/app/components/templates-page/templates-page.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { Router } from '@angular/router'
+import { LayoutMainService } from 'src/app/services/layout-main.service';
+import { TemplateManagerService } from 'src/app/services/template-manager.service';
+import { Template } from 'src/app/models/template.model';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: '',
@@ -6,12 +12,40 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./templates-page.component.scss']
 })
 
-export class TemplatesPageComponent implements OnInit {
-  constructor() {
+export class TemplatesPageComponent implements OnInit, AfterViewInit{
 
+  displayedColumns = [
+    "name",
+    "deception_score",
+    "template_type",
+    "created_by",
+   ];
+   templatesData = new MatTableDataSource<Template>();
+   search_input = ''
+   @ViewChild(MatSort) sort: MatSort
+
+  constructor(
+    private templateSvc: TemplateManagerService,
+    private router: Router,
+    private layoutSvc: LayoutMainService,
+    ) {
+      layoutSvc.setTitle("Templates");
    }
 
   ngOnInit() {
+    this.templateSvc.getAllTemplates().subscribe((data: any) => {
+      this.templatesData.data = data as Template[]
+    })
   }
 
+  ngAfterViewInit() : void {
+    this.templatesData.sort = this.sort
+  }
+
+  public filterTemplates = (value: string) => {
+    this.templatesData.filter = value.trim().toLocaleLowerCase();
+  }
+  public editTemplate(template: Template){
+    this.router.navigate(['/templatemanager', template.template_uuid]);
+  }
 }

--- a/client/AdminUI/src/app/services/template-manager.service.ts
+++ b/client/AdminUI/src/app/services/template-manager.service.ts
@@ -18,6 +18,21 @@ export class TemplateManagerService {
     return this.http.get('http://localhost:8000/api/v1/templates', headers);
   }
 
+  // getAllTemplates() {
+  //   return new Promise((resolve, reject) => {
+  //     this.http
+  //     .get('http://localhost:8000/api/v1/templates', headers)
+  //     .subscribe(
+  //       (success) => {
+  //         return success
+  //       },
+  //       (error) => {
+  //         return error
+  //       }
+  //     )
+  //   })
+  // }
+
   //GET a single template using the provided temlpate_uuid
   getTemplate(uuid: string) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## 🗣 Description

A page to display a list of all templates was created. Search and sort functionality added to list. Ability to create a new template possible through create new template button at the top of the page. Templates in list can be selected for edit in the template manager page.

The Template Manager page has been updated to show the deception calculations on  the right hand side. The template list portion has been removed. The deception calc button has been removed. 

The deception calc page has been left in case of future use, will delete once the current design iteration is mature.

## 💭 Motivation and Context

Discusion with Jason / CPA-122

## 🧪 Testing

Hands on testing of:
- List filter capability.
- List sort
- Previous functionality from template manager page and deception calc page

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
