### PR TITLE
Delete subscription dialog added.

### DIFF
--- a/client/AdminUI/src/app/app.module.ts
+++ b/client/AdminUI/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { AddCustomerDialogComponent } from './components/customers/add-customer-
 import { AddContactDialogComponent } from './components/contacts/add-contact-dialog/add-contact-dialog.component';
 import { ViewContactDialogComponent } from './components/contacts/view-contact-dialog/view-contact-dialog.component';
 import { ViewSubscriptionComponent } from './components/subscriptions/view-subscription/view-subscription.component';
+import { DeleteSubscription, DeleteSubscriptionDialog} from 'src/app/components/subscriptions/delete-subscription/delete-subscription.component'
 
 
 
@@ -64,6 +65,8 @@ import { ViewSubscriptionComponent } from './components/subscriptions/view-subsc
     AddContactDialogComponent,
     ViewContactDialogComponent,
     ViewSubscriptionComponent,
+    DeleteSubscription,
+    DeleteSubscriptionDialog,
   ],
   imports: [
     BrowserModule,

--- a/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription-dialog.html
+++ b/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription-dialog.html
@@ -1,0 +1,19 @@
+<h1 mat-dialog-title>Delete '{{data.subscription?.name}}'?</h1>
+<div mat-dialog-content>
+    <p><b>Warning</b> - Deleting a subscription is a significantly destructive task. All data and statistics related to the subscription will be lost </p>
+    <p>In order to delete a subscription, you must type (or copy) the name of the subscription into the box below</p>
+    <mat-form-field>
+        <mat-label>Subscription Name</mat-label>
+        <input matInput id="confirmDeleteInput" [(ngModel)]="data.confirmName" (ngModelChange)="confirmValueVhange($event)">
+    </mat-form-field>
+</div>
+<div mat-dialog-actions >
+    <button mat-button (click)="onNoClick()">Cancel</button>
+    <div 
+        matTooltip="The entry field must match the name of the subscription to delete it" 
+        matTooltipPosition="right"
+        matTooltipShowDelay="500"
+        [matTooltipDisabled]="canDelete">
+        <button mat-button [mat-dialog-close]="true" [disabled]="!canDelete" cdkFocusInitial>Delete</button>
+    </div>
+</div>

--- a/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription.component.html
+++ b/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription.component.html
@@ -1,0 +1,6 @@
+<button
+id="delete-subscription"
+mat-raised-button
+color="warn"
+(click)="openDialog()" > Delete Subscription</button>
+    

--- a/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription.component.ts
+++ b/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription.component.ts
@@ -1,0 +1,80 @@
+import { Component, Inject, Input} from '@angular/core';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { Subscription } from 'src/app/models/subscription.model';
+import { SubscriptionService } from 'src/app/services/subscription.service';
+import { Router } from '@angular/router';
+
+export interface DialogData {
+  confirmName: string;
+  subscription: Subscription;
+}
+
+@Component({
+  selector: 'delete-subscription',
+  templateUrl: 'delete-subscription.component.html',
+  styleUrls: ['delete-subscription.component.scss'],
+})
+export class DeleteSubscription {
+
+  @Input()
+  subscription: Subscription;
+
+  constructor(
+      public dialog: MatDialog,
+      private _snackBar: MatSnackBar,
+      public subscriptionsrv: SubscriptionService,
+      private router: Router
+      ) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open(DeleteSubscriptionDialog, {
+      width: '450px',
+      data: {subscription: this.subscription}
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if(result){
+        this.subscriptionsrv.deleteSubscription(this.subscription)
+        .then(
+            (success) => {
+              this.router.navigate(['/subscriptions']);
+            },
+            (error) => {
+                let snackBarRef = this._snackBar.open('Subscription Deletion Failed','Dismiss',{duration: 5000});
+            }
+        )
+      }
+    });
+  }
+
+}
+
+@Component({
+  selector: 'delete-subscription-dialog',
+  templateUrl: 'delete-subscription-dialog.html',
+})
+export class DeleteSubscriptionDialog {
+
+    subscription: Subscription;
+    canDelete: boolean;
+
+    constructor(
+        public dialogRef: MatDialogRef<DeleteSubscriptionDialog>,
+        @Inject(MAT_DIALOG_DATA) public data: DialogData) {
+            this.canDelete = false;
+            this.subscription = data.subscription;
+        }
+
+    confirmValueVhange(value){
+        if(value === this.subscription.name){
+            this.canDelete = true;
+        } else {
+            this.canDelete = false;
+        }
+    }
+    onNoClick(): void {
+        this.dialogRef.close();
+    }
+
+}

--- a/client/AdminUI/src/app/components/subscriptions/view-subscription/view-subscription.component.html
+++ b/client/AdminUI/src/app/components/subscriptions/view-subscription/view-subscription.component.html
@@ -5,20 +5,19 @@
         <div>
             <mat-label class="h6">Customer</mat-label>
         </div>
-
         <div class="p-2 card w-50 mb-1">
-            <div>{{data.customer.name}}</div>
-            <div>{{data.customer.identifier}}</div>
-            <div>{{data.customer.address_1}}</div>
-            <div>{{data.customer.address_2}}</div>
-            <div>{{data.customer.city}}, {{data.customer.state}}</div>
+            <div>{{data?.customer.name}}</div>
+            <div>{{data?.customer.identifier}}</div>
+            <div>{{data?.customer.address_1}}</div>
+            <div>{{data?.customer.address_2}}</div>
+            <div>{{data?.customer.city}}, {{data?.customer.state}}</div>
         </div>
 
         <div>
             <mat-form-field appearance="outline">
                 <mat-label>Primary Contact</mat-label>
                 <mat-select>
-                    <mat-option *ngFor="let c of data.customer.contact_list" [value]="c">
+                    <mat-option *ngFor="let c of data?.customer.contact_list" [value]="c">
                         {{c.first_name}} {{c.last_name}} - {{c.email}}
                     </mat-option>
                 </mat-select>
@@ -29,7 +28,7 @@
             <mat-label class="h6">Start Date</mat-label>
             <div>
                 <mat-form-field appearance="outline" class="mb-4">
-                    <input matInput [matDatepicker]="picker" [(ngModel)]="data.subscription.start_date">
+                    <input matInput [matDatepicker]="picker" [(ngModel)]="data?.subscription.start_date">
                     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                     <mat-datepicker #picker></mat-datepicker>
                 </mat-form-field>
@@ -40,7 +39,7 @@
                 <div class="text-muted">The customer's page will be analyzed 
                     to send phishing emails relevant to their industry.
                 </div>
-                <input [(ngModel)]="data.subscription.url" type="text" class="form-control mb-4">
+                <input [(ngModel)]="data?.subscription.url" type="text" class="form-control mb-4">
             </div>
 
             <div>
@@ -48,7 +47,7 @@
                 <div class="text-muted">Enter words that describe the
                     organization, separated by commas.
                     They will be used to select applicable templates.</div>
-                <textarea autosize appearance="outline" class="form-control mb-4" [(ngModel)]="data.subscription.keywords"></textarea>
+                <textarea autosize appearance="outline" class="form-control mb-4" [(ngModel)]="data?.subscription.keywords"></textarea>
             </div>
 
             <div>
@@ -70,7 +69,9 @@
         </div>
 
 
+        
         <div class="text-right mt-3">
+            <delete-subscription [subscription]="data?.subscription"></delete-subscription>
             <button mat-raised-button color="primary">Create and Launch Subscription</button>
         </div>
 

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -233,7 +233,7 @@
           New Template
         </button> -->
         <button
-          id="save-button"
+          id="delete-button"
           class="d-flex"
           mat-raised-button
           color="warn"

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -244,7 +244,7 @@ export class TemplateManagerComponent implements OnInit {
           .updateTemplate(templateToSave)
           .then(
             (success) => {
-              this.router.navigate(['/templatespage']);
+              this.router.navigate(['/templates']);
               // let retTemplate = <Template>success
               // this.updateTemplateInList(retTemplate)
             },
@@ -255,7 +255,7 @@ export class TemplateManagerComponent implements OnInit {
         this.templateManagerSvc
           .saveNewTemplate(templateToSave).then(
           (success) => {
-            this.router.navigate(['/templatespage']);
+            this.router.navigate(['/templates']);
             // let retTemplate = new Template({
             //   'template_uuid': success['template_uuid'],
             //   'name': templateToSave.name,

--- a/client/AdminUI/src/app/services/subscription.service.ts
+++ b/client/AdminUI/src/app/services/subscription.service.ts
@@ -56,6 +56,21 @@ export class SubscriptionService {
 
     return subscription
   }
+  public deleteSubscription(subscription: Subscription) {
+    console.log(subscription)
+    return new Promise((resolve,reject) => {
+      this.http
+      .delete(`${environment.apiEndpoint}/api/v1/subscription/${subscription.subscription_uuid}/`)
+      .subscribe(
+        success => {
+          resolve(success);
+        },
+        error => {
+          reject(error)
+        }
+      )
+    })
+  }
 
 
   /**

--- a/client/AdminUI/src/app/services/template-manager.service.ts
+++ b/client/AdminUI/src/app/services/template-manager.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable, OnInit } from '@angular/core';
+import { environment } from 'src/environments/environment';
 import { Router } from '@angular/router';
 
 import { Template, TemplateShort } from 'src/app/models/template.model';
@@ -15,7 +16,7 @@ export class TemplateManagerService {
 
   //GET a list of all templates
   getAllTemplates() {
-    return this.http.get('http://localhost:8000/api/v1/templates', headers);
+    return this.http.get(`${environment.apiEndpoint}/api/v1/templates`, headers);
   }
 
   // getAllTemplates() {
@@ -37,7 +38,7 @@ export class TemplateManagerService {
   getTemplate(uuid: string) {
     return new Promise((resolve, reject) => {
       this.http
-        .get(`http://localhost:8000/api/v1/template/${uuid}`)
+        .get(`${environment.apiEndpoint}/api/v1/template/${uuid}`)
         .subscribe(
           success => {
             resolve(success);
@@ -55,7 +56,7 @@ export class TemplateManagerService {
   saveNewTemplate(template: Template) {
     return new Promise((resolve, reject) => {
       this.http
-        .post('http://localhost:8000/api/v1/templates/', template)
+        .post(`${environment.apiEndpoint}/api/v1/templates/`, template)
         .subscribe(
           success => {
             resolve(success);
@@ -72,7 +73,7 @@ export class TemplateManagerService {
   updateTemplate(template: Template) {
     return new Promise((resolve, reject) => {
       this.http
-        .patch(`http://localhost:8000/api/v1/template/${template.template_uuid}/`, template)
+        .patch(`${environment.apiEndpoint}/api/v1/template/${template.template_uuid}/`, template)
         .subscribe(
           success => {
             resolve(success);
@@ -88,7 +89,7 @@ export class TemplateManagerService {
   deleteTemplate(template: Template) {
     return new Promise((resolve,reject) => {
       this.http
-      .delete(`http://localhost:8000/api/v1/template/${template.template_uuid}/`)
+      .delete(`${environment.apiEndpoint}/api/v1/template/${template.template_uuid}/`)
       .subscribe(
         success => {
           resolve(success);


### PR DESCRIPTION
## 🗣 Description

Delete subscription dialog created and added to the 'view-subscription' page. Modal pops up and explains the consequences of deleting a subscription. Requires the user enter the name of the subscription, and if done so, the subscription can be deleted. Calls the API endpoint for subscription deletion. Tooltip explanations and error messages included for a failed deletion.

Minor changes to view-subscription to remove some error messages from appearing in the console. 

Changes to template page to use the env url rather than hard coded localhost.

## 💭 Motivation and Context

CPA-131. (Delete Subscription) Add Delete button and prompts to the subscription edit page

## 🧪 Testing

Testing in app against the local database. 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
