### PR TITLE
Feature/cpa 207 186

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,7 +7,7 @@ import_heading_thirdparty=Third-Party Libraries
 import_heading_firstparty=cisagov Libraries
 
 # Should be auto-populated by seed-isort-config hook
-known_third_party=api,bs4,bson,celery,config,database,django,drf_yasg,faker,lcgit,motor,nltk,pytest,requests,rest_framework,schematics,service,sklearn,test_validators,weasyprint,yaml
+known_third_party=api,boto3,botocore,bs4,bson,celery,config,database,django,drf_yasg,faker,lcgit,motor,nltk,pytest,requests,rest_framework,schematics,service,sklearn,test_validators,weasyprint,yaml
 
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=

--- a/controller/src/api/models/subscription_models.py
+++ b/controller/src/api/models/subscription_models.py
@@ -4,6 +4,7 @@ Models.
 These are not Django Models, there are created using Schematics Models
 """
 # Third-Party Libraries
+from api.models.customer_models import CustomerContactModel
 from database.repository.models import Model
 from database.repository.types import (
     BooleanType,
@@ -16,8 +17,6 @@ from database.repository.types import (
     StringType,
     UUIDType,
 )
-
-from api.models.customer_models import CustomerContactModel
 
 
 class SubscriptionTargetModel(Model):
@@ -164,7 +163,7 @@ class SubscriptionModel(Model):
     keywords = StringType()
     start_date = DateTimeType()
     # commented out fields for now are unused for the time
-    # end_date = DateTimeType()
+    end_date = DateTimeType()
     # report_count = IntType()
     gophish_campaign_list = ListType(ModelType(GoPhishCampaignsModel))
     # first_report_timestamp = DateTimeType()

--- a/controller/src/api/serializers/subscriptions_serializers.py
+++ b/controller/src/api/serializers/subscriptions_serializers.py
@@ -5,9 +5,8 @@ These are Django Rest Framework Serializers. These are used for
 serializing data coming from the db into a request response.
 """
 # Third-Party Libraries
-from rest_framework import serializers
-
 from api.serializers.customer_serializers import CustomerContactSerializer
+from rest_framework import serializers
 
 
 class SubscriptionTargetSerializer(serializers.Serializer):
@@ -101,6 +100,7 @@ class GoPhishCampaignsSerializer(serializers.Serializer):
     timeline = GoPhishTimelineSerializer(many=True)
     target_email_list = SubscriptionTargetSerializer(many=True, required=False)
 
+
 # class GoPhishTemplateSerializer(serializers.Serializer):
 #     """
 #     This is the GoPhish Temaplates Serializer.
@@ -108,7 +108,6 @@ class GoPhishCampaignsSerializer(serializers.Serializer):
 #     This is a formats the data coming out of the Db.
 #     """
 #     template_id = serializers.IntegerField(required=False)
-    
 
 
 class SubscriptionGetSerializer(serializers.Serializer):
@@ -126,6 +125,7 @@ class SubscriptionGetSerializer(serializers.Serializer):
     url = serializers.CharField(required=True, max_length=100)
     keywords = serializers.CharField(max_length=100)
     start_date = serializers.DateTimeField()
+    end_date = serializers.DateTimeField()
     gophish_campaign_list = GoPhishCampaignsSerializer(many=True)
     primary_contact = CustomerContactSerializer()
     status = serializers.CharField(max_length=100)
@@ -153,6 +153,7 @@ class SubscriptionPostSerializer(serializers.Serializer):
     url = serializers.CharField(required=True, max_length=100)
     keywords = serializers.CharField(max_length=100)
     start_date = serializers.DateTimeField()
+    end_date = serializers.DateTimeField(required=False)
     gophish_campaign_list = GoPhishCampaignsSerializer(many=True)
     primary_contact = CustomerContactSerializer()
     status = serializers.CharField(max_length=100)
@@ -185,6 +186,7 @@ class SubscriptionPatchSerializer(serializers.Serializer):
     url = serializers.CharField(required=False, max_length=100)
     keywords = serializers.CharField(max_length=100)
     start_date = serializers.DateTimeField(required=False)
+    end_date = serializers.DateTimeField(required=False)
     gophish_campaign_list = GoPhishCampaignsSerializer(many=True, required=False)
     primary_contact = CustomerContactSerializer(required=False)
     status = serializers.CharField(max_length=100, required=False)
@@ -207,6 +209,7 @@ class SubscriptionPatchResponseSerializer(serializers.Serializer):
     url = serializers.CharField(required=False, max_length=100)
     keywords = serializers.CharField(max_length=100)
     start_date = serializers.DateTimeField()
+    end_date = serializers.DateTimeField()
     gophish_campaign_list = GoPhishCampaignsSerializer(many=True)
     primary_contact = CustomerContactSerializer()
     status = serializers.CharField(max_length=100)

--- a/controller/src/api/utils/subscription_utils.py
+++ b/controller/src/api/utils/subscription_utils.py
@@ -3,16 +3,13 @@
 from datetime import datetime, timedelta
 
 # Third-Party Libraries
-from lcgit import lcg
-from celery.task.control import revoke
-
 # Local Libraries
-from api.serializers.subscriptions_serializers import SubscriptionPatchSerializer
-from api.models.subscription_models import SubscriptionModel, validate_subscription
-
 from api.manager import CampaignManager
-
+from api.models.subscription_models import SubscriptionModel, validate_subscription
+from api.serializers.subscriptions_serializers import SubscriptionPatchSerializer
 from api.utils import db_utils
+from celery.task.control import revoke
+from lcgit import lcg
 
 campaign_manager = CampaignManager()
 
@@ -28,7 +25,7 @@ def get_campaign_dates(start_date_string):
         start_date = datetime.strptime(
             start_date_string, "%Y-%m-%dT%H:%M:%S"
         )  # Format inbound 2020-03-10T09:30:25
-    except:
+    except Exception:
         start_date = datetime.strptime(
             start_date_string, "%Y-%m-%dT%H:%M:%S.%fZ"
         )  # Format inbound 2020-03-10T09:30:25.227Z
@@ -139,3 +136,27 @@ def stop_subscription(subscription):
     )
 
     return resp
+
+
+def get_sub_end_date(start_date_string):
+    """
+    Get Sub end date.
+
+    Using given start date,
+    generate the standered end_date 90 after start.
+    """
+    try:
+        start_date = datetime.strptime(
+            start_date_string, "%Y-%m-%dT%H:%M:%S"
+        )  # Format inbound 2020-03-10T09:30:25
+    except Exception:
+        start_date = datetime.strptime(
+            start_date_string, "%Y-%m-%dT%H:%M:%S.%fZ"
+        )  # Format inbound 2020-03-10T09:30:25.227Z
+    ninety_days = timedelta(days=90)
+    # your calculated date
+    # start: start_date
+    # 60 days later: start_date + 60_days
+    # send all at once, send by 60 days, end at 90
+    ninety_days_later = start_date + ninety_days
+    return ninety_days_later

--- a/controller/src/api/views/subscription_views.py
+++ b/controller/src/api/views/subscription_views.py
@@ -22,7 +22,6 @@ from api.serializers.subscriptions_serializers import (
     SubscriptionPostResponseSerializer,
     SubscriptionPostSerializer,
 )
-from api.utils import subscription_utils
 from api.utils.db_utils import (
     delete_single,
     get_list,
@@ -30,7 +29,12 @@ from api.utils.db_utils import (
     save_single,
     update_single,
 )
-from api.utils.subscription_utils import get_campaign_dates, target_list_divide
+from api.utils.subscription_utils import (
+    get_campaign_dates,
+    get_sub_end_date,
+    stop_subscription,
+    target_list_divide,
+)
 from api.utils.template_utils import format_ztime, personalize_template
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -95,30 +99,62 @@ class SubscriptionsListView(APIView):
             post_data["customer_uuid"], "customer", CustomerModel, validate_customer
         )
 
+        # Get start date then quater of start date and create names to check
+        start_date = post_data.get(
+            "start_date", datetime.today().strftime("%Y-%m-%dT%H:%M:%S")
+        )
+
+        end_date = get_sub_end_date(start_date)
+        end_date_str = end_date.strftime("%Y-%m-%dT%H:%M:%S")
+
+        # here we generate the increments on the subscriton names
+        # {identifier}_{inc}.{sub_number}
+        # FORD_1.1 < first one created
+        # FORD_2.1 < second created before first ends
+        # FORD_1.2 < created after both end
+        # FORD_2.2 < created if both first hace been created AND second is created but still running
+        # if a sub is created that falls into
+        # {cust}_{sub in 90 days from startdate of _1}.{total}
         # Get list of all subscriptions for incrementing sub name
-        customer_filter = {"customer_uuid": post_data["customer_uuid"]}
+        # subscription_filter = {"customer_uuid": post_data["customer_uuid"]}
+
         subscription_list = get_list(
-            customer_filter, "subscription", SubscriptionModel, validate_subscription
-        )
-        increment_position = (
-            4  # The position the individual subscriptions is being counted from
+            {"customer_uuid": post_data["customer_uuid"]},
+            "subscription",
+            SubscriptionModel,
+            validate_subscription,
         )
 
-        previous_incrments = []
-        for sub in subscription_list:
-            previous_incrments.append(sub["name"].split(".")[increment_position])
+        if len(subscription_list) == 0:
+            # If no subscription was created, create first one:
+            # {customer['identifier']}_1.1
+            base_name = f"{customer['identifier']}_1.1"
 
-        first_increment = (
-            1  # Modify when the first increment value has a purpose determined
-        )
-        second_increment = (
-            1 if not previous_incrments else int(max(previous_incrments)) + 1
-        )
+        else:
+            # Get all names, then split off the identifyers from name
+            names = [x["name"] for x in subscription_list]
+            list_tupe = []
+            for name in names:
+                int_ind, sub_id = name.split(".")
+                _, sub = int_ind.split("_")
+                list_tupe.append((sub, sub_id))
+            # now sort tuple list by second element
+            list_tupe.sort(key=lambda tup: tup[1])
+            # get last run inc values
+            last_ran_x, last_ran_y = list_tupe[-1]
+
+            # now check to see there are any others running durring.
+            active_subscriptions = [x for x in subscription_list if x["active"]]
+            if len(active_subscriptions) <= 0:
+                # if none are actvie, check last running number and create new name
+                next_run_x, next_run_y = "1", str(int(last_ran_y) + 1)
+            else:
+                next_run_x, next_run_y = str(int(last_ran_x) + 1), last_ran_y
+
+            base_name = f"{customer['identifier']}_{next_run_x}.{next_run_y}"
 
         # Generate sub name using customer and increment info
-        post_data[
-            "name"
-        ] = f"{customer['identifier']}.{customer['contact_list'][0]['first_name']}.{customer['contact_list'][0]['last_name']}.{first_increment}.{second_increment}"
+        post_data["name"] = base_name
 
         # Get all Email templates for calc
         email_template_params = {"template_type": "Email", "retired": False}
@@ -148,9 +184,6 @@ class SubscriptionsListView(APIView):
         ]
 
         # Get the next date Intervals, if no startdate is sent, default today
-        start_date = post_data.get(
-            "start_date", datetime.today().strftime("%Y-%m-%dT%H:%M:%S")
-        )
         campaign_data_list = get_campaign_dates(start_date)
 
         # Return 15 of the most relevant templates
@@ -174,38 +207,26 @@ class SubscriptionsListView(APIView):
             index += 1
 
         # Data for GoPhish
-        first_name = post_data.get("primary_contact").get("first_name", "")
-        last_name = post_data.get("primary_contact").get("last_name", "")
-        # get User Groups
-        # user_groups = campaign_manager.get("user_group")
-
         # create campaigns
-        group_number = 0
+        group_number = 1
         gophish_campaign_list = []
         for campaign_info in campaign_data_list:
             campaign_group = f"{post_data['name']}.Targets.{group_number} "
             campaign_info["name"] = f"{post_data['name']}.{group_number}"
             group_number += 1
-            # if campaign_group not in [group.name for group in user_groups]:
             target_group = campaign_manager.create(
                 "user_group",
                 group_name=campaign_group,
                 target_list=campaign_info["targets"],
             )
-            # else:
-            #     # get group from list
-            #     for user_group in user_groups:
-            #         if user_group.name == campaign_group:
-            #             target_group = user_group
-            #             break
             gophish_campaign_list.extend(
                 self.__create_and_save_campaigns(
-                    campaign_info, target_group, first_name, last_name, landing_page
+                    campaign_info, target_group, landing_page, end_date
                 )
             )
 
         post_data["gophish_campaign_list"] = gophish_campaign_list
-
+        post_data["end_date"] = end_date_str
         created_response = save_single(
             post_data, "subscription", SubscriptionModel, validate_subscription
         )
@@ -216,7 +237,7 @@ class SubscriptionsListView(APIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def __create_and_save_campaigns(
-        self, campaign_info, target_group, first_name, last_name, landing_page
+        self, campaign_info, target_group, landing_page, end_date
     ):
         """
         Create and Save Campaigns.
@@ -234,15 +255,11 @@ class SubscriptionsListView(APIView):
                 name=template["name"], template=template["data"]
             )
             campaign_start = campaign_info["start_date"].strftime("%Y-%m-%d")
-            campaign_end = campaign_info["send_by_date"].strftime("%Y-%m-%d")
+            campaign_end = end_date.strftime("%Y-%m-%d")
 
             if created_template is not None:
                 template_name = created_template.name
-                if not campaign_info["name"]:
-                    campaign_name = f"{first_name}.{last_name}.1.1 {template_name} {campaign_start}-{campaign_end}"
-                else:
-                    campaign_name = f"{campaign_info['name']}.{template_name}.{campaign_start}-{campaign_end}"
-                print(campaign_info["start_date"])
+                campaign_name = f"{campaign_info['name']}.{template_name}.{campaign_start}-{campaign_end}"
                 campaign = campaign_manager.create(
                     "campaign",
                     campaign_name=campaign_name,
@@ -453,7 +470,7 @@ class SubscriptionStopView(APIView):
         )
 
         # Stop subscription
-        resp = subscription_utils.stop_subscription(subscription)
+        resp = stop_subscription(subscription)
 
         # Return updated subscriptions
         serializer = SubscriptionPatchResponseSerializer(resp)

--- a/controller/src/scripts/create_dummy_data.py
+++ b/controller/src/scripts/create_dummy_data.py
@@ -85,7 +85,9 @@ def main():
 
     for subscription in subscriptions:
         subscription["customer_uuid"] = customer
-        subscription["start_date"] = datetime.today()
+        subscription["start_date"] = datetime.today().strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )  # 2020-03-10T09:30:25"
         try:
             resp = requests.post(
                 "http://localhost:8000/api/v1/subscriptions/", json=subscription

--- a/controller/src/scripts/create_dummy_data.py
+++ b/controller/src/scripts/create_dummy_data.py
@@ -61,7 +61,9 @@ def main():
     created_customer_uuids = []
     for customer in customers:
         try:
-            resp = requests.post("http://localhost:8000/api/v1/customers/", json=customer)
+            resp = requests.post(
+                "http://localhost:8000/api/v1/customers/", json=customer
+            )
             resp.raise_for_status()
         except requests.exceptions.HTTPError as err:
             raise err
@@ -71,26 +73,19 @@ def main():
             created_customer_uuid = resp_json["customer_uuid"]
             print("created customer_uuid: {}".format(created_customer_uuid))
             created_customer_uuids.append(created_customer_uuid)
-        except:
+        except Exception as err:
+            print(err)
             pass
 
     print("Step 3/3: create subscriptions...")
 
     subscriptions = json_data["subscription_data"]
+    customer = created_customer_uuids[0]
     created_subcription_uuids = []
 
     for subscription in subscriptions:
-        print(subscription)
-        # If testing data (identified by 'testing_customer'), get customer_uuid from db
-        if "testing_customer_identifier" in subscription.keys():       
-            existing_customers = requests.get("http://localhost:8000/api/v1/customers/")
-            print(existing_customers.json())
-            if existing_customers:
-                for customer in existing_customers.json():
-                    if customer["identifier"] == subscription["testing_customer_identifier"]:
-                        subscription["customer_uuid"] = customer["customer_uuid"]
-                subscription.pop("testing_customer_identifier", None)
-
+        subscription["customer_uuid"] = customer
+        subscription["start_date"] = datetime.today()
         try:
             resp = requests.post(
                 "http://localhost:8000/api/v1/subscriptions/", json=subscription
@@ -117,7 +112,7 @@ def main():
         data = {
             "created_customers": created_customer_uuids,
             "created_subcription_uuids": created_subcription_uuids,
-            "created_template_uuids": created_template_uuids
+            "created_template_uuids": created_template_uuids,
         }
         json.dump(data, outfile, indent=2)
     print("Finished.....")

--- a/controller/src/scripts/data/dummy_data.json
+++ b/controller/src/scripts/data/dummy_data.json
@@ -46,10 +46,10 @@
   "subscription_data": [
     {
       "active": true,
-      "customer_uuid": "d2e45f21-0460-4a05-865f-a30cb8b6336a",
+      "customer_uuid": "changeme",
       "gophish_campaign_list": [],
       "keywords": "research development government work job",
-      "name": "SC-1031.Matt.Daemon.1.1",
+      "name": "changeme",
       "primary_contact": {
         "active": true,
         "email": "Matt.Daemon@example.com",
@@ -109,10 +109,10 @@
     },
     {
       "active": true,
-      "customer_uuid": "6068d85a-4f83-4b5a-958e-a179e5b4c205",
+      "customer_uuid": "changeme",
       "gophish_campaign_list": [],
       "keywords": "search query google",
-      "name": "SC-1221.Ben.Aflex.1.1",
+      "name": "changme",
       "primary_contact": {
         "active": true,
         "email": "foo.bar@example.com",

--- a/controller/src/scripts/data/dummy_data.json
+++ b/controller/src/scripts/data/dummy_data.json
@@ -105,7 +105,6 @@
         }
       ],
       "templates_selected_uuid_list": [],
-      "testing_customer_identifier": "BoB",
       "url": "https://inl.gov"
     },
     {
@@ -169,7 +168,6 @@
         }
       ],
       "templates_selected_uuid_list": [],
-      "testing_customer_identifier": "NHL",
       "url": "https://google.com"
     }
   ]


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->

CPA-207 and CPA-186

When creating a subscription, the template selector can only pick templates that are not retired. 

When creating a subscription, it will be uniquely named in the format {customer_identifier}_{secondary_id}.{primary_id}

This will calculate and increment them accordingly

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needing to uniquely name the subscriptions is a core functionality for gophish and creating campaigns, groups and templates. 

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested via `make init` and swagger.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

NOTE: you will need to clear out our DB to use this, this will break with other items not in naming format. 

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
