### PR TITLE
Added tag selection dialog to template manager

### DIFF
--- a/client/AdminUI/src/app/app.module.ts
+++ b/client/AdminUI/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { SubDashboardComponent } from './components/subscriptions/sub-dashboard/sub-dashboard.component';
 import { TimelineComponent } from './components/subscriptions/timeline/timeline.component';
 import { ConfirmComponent } from './components/dialogs/confirm/confirm.component';
+import { TagSelectionComponent } from './components/dialogs/tag-selection/tag-selection.component';
 
 @NgModule({
   declarations: [
@@ -79,6 +80,7 @@ import { ConfirmComponent } from './components/dialogs/confirm/confirm.component
     SubDashboardComponent,
     TimelineComponent,
     ConfirmComponent,
+    TagSelectionComponent,
   ],
   imports: [
     BrowserModule,

--- a/client/AdminUI/src/app/components/customers/customers.component.html
+++ b/client/AdminUI/src/app/components/customers/customers.component.html
@@ -46,7 +46,7 @@
             
 
             <mat-header-row *matHeaderRowDef="displayed_columns"></mat-header-row>
-            <mat-row class="cursor-pointer" *matRowDef="let row; columns: displayed_columns" (click)="setCustomer(row.customer_uuid)"></mat-row>
+            <mat-row *matRowDef="let row; columns: displayed_columns" (click)="setCustomer(row.customer_uuid)"></mat-row>
         </mat-table>
     </div>
     <div class="container-fluid" *ngIf="customerSvc.showCustomerInfo">

--- a/client/AdminUI/src/app/components/dialogs/tag-selection/tag-selection.component.html
+++ b/client/AdminUI/src/app/components/dialogs/tag-selection/tag-selection.component.html
@@ -1,0 +1,17 @@
+<h3>Select a Tag to Insert</h3>
+
+<div style="max-height: 50vh; overflow: auto;">
+    <table class="table-1">
+        <tr *ngFor="let t of templateManagerSvc.tags" class="cursor-pointer" (click)="dialogRef.close(t.tag)">
+            <td>
+                {{t.tag}}
+            </td>
+            <td>
+                {{t.description}}
+            </td>
+        </tr>
+    </table>
+</div>
+<div class="mt-3 d-flex flex-row justify-content-end">
+    <button mat-flat-button color="basic" (click)="onCancelClick()">Cancel</button>
+</div>

--- a/client/AdminUI/src/app/components/dialogs/tag-selection/tag-selection.component.ts
+++ b/client/AdminUI/src/app/components/dialogs/tag-selection/tag-selection.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { TemplateManagerService } from 'src/app/services/template-manager.service';
+
+@Component({
+  selector: 'app-tag-selection',
+  templateUrl: './tag-selection.component.html'
+})
+export class TagSelectionComponent implements OnInit {
+
+  /**
+   * Constructor.
+   * @param dialogRef 
+   * @param templateManagerSvc 
+   */
+  constructor(
+    public dialogRef: MatDialogRef<TagSelectionComponent>,
+    public templateManagerSvc: TemplateManagerService
+  ) { }
+
+  /**
+   * 
+   */
+  ngOnInit(): void {
+  }
+
+  /**
+   * Closes the dialog.
+   */
+  onCancelClick() {
+    this.dialogRef.close();
+  }
+}

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -67,29 +67,12 @@
               </span>
             </ng-template>
             <div>
+              <button mat-raised-button color="primary" (click)="openTagChoice()" class="hidden-insert-tag-button d-none">Insert Tag</button>
               <angular-editor #angularEditor [style.height.px]="text_editor_height" formControlName="templateHTML"
                 [config]="editorConfig"></angular-editor>
             </div>
           </mat-tab>
-          <mat-tab>
-            <ng-template mat-tab-label>
-              <span [ngClass]="{
-                  'tab-form-error':
-                    currentTemplateFormGroup.controls.templateHTML.hasError(
-                      'required'
-                    ) && currentTemplateFormGroup.controls.templateHTML.touched
-                }">Source View
-              </span>
-            </ng-template>
-            <div class="d-flex flex-column mt-2">
-              <mat-form-field class="flex-grow-1">
-                <mat-label>Template HTML content</mat-label>
-                <textarea [style.height.px]="text_editor_height" [style.margin-bottom.px]="text_area_bot_marg" matInput
-                  formControlName="templateHTML" [value]="currentTemplateFormGroup.value.templateHTML"
-                  placeholder="Select a template on the left to edit" class="flex-1" style="resize: none;"></textarea>
-              </mat-form-field>
-            </div>
-          </mat-tab>
+          
           <!-- <mat-tab label="Template Attributes"
           [ngClass]="{'testing' : currentTemplateFormGroup.controls.templateFromAddress.hasError('required')}"
           class="mb-3"> -->

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -66,8 +66,8 @@
                 }">HTML View
               </span>
             </ng-template>
-            <div>
-              <button mat-raised-button color="primary" (click)="openTagChoice()" class="hidden-insert-tag-button d-none">Insert Tag</button>
+            <button mat-raised-button color="primary" (click)="openTagChoice()" class="hidden-insert-tag-button d-none">Insert Tag</button>
+            <div>              
               <angular-editor #angularEditor [style.height.px]="text_editor_height" formControlName="templateHTML"
                 [config]="editorConfig"></angular-editor>
             </div>
@@ -162,7 +162,7 @@
             <ng-template mat-tab-label>
               Subscriptions
             </ng-template>
-            <div class=" p-3 flex-column" [style.height.px]="text_editor_height">
+            <div class="p-3 flex-column" [style.height.px]="text_editor_height">
               <mat-table *ngIf="this.pcaSubscriptions.data.length > 0" class="w-100" [dataSource]="pcaSubscriptions">
                 <ng-container matColumnDef="name">
                   <mat-header-cell *matHeaderCellDef>

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -33,8 +33,6 @@ export class TemplateManagerComponent implements OnInit {
   dialogRefConfirm: MatDialogRef<ConfirmComponent>;
   dialogRefTagSelection: MatDialogRef<TagSelectionComponent>;
 
-  @ViewChild('angularEditor') angularEditor: any;
-
   //Full template list variables
   search_input: string;
 
@@ -458,7 +456,7 @@ export class TemplateManagerComponent implements OnInit {
    * Clicking it clicks a hidden button to get us back into Angular.
    */
   addInsertTagButtonIntoEditor() { 
-    let btnClearFormatting = $(this.angularEditor.doc).find("[title='Horizontal Line']")[0];
+    let btnClearFormatting = $(this.angularEditorEle.doc).find("[title='Horizontal Line']")[0];
     let attribs = btnClearFormatting.attributes;
     // this assumes that the _ngcontent attribute occurs first
     let ngcontent = attribs.item(0).name;
@@ -472,7 +470,7 @@ export class TemplateManagerComponent implements OnInit {
    * Opens a dialog that presents the tag options.
    */
   openTagChoice() {
-    this.angularEditor.textArea.nativeElement.focus();
+    this.angularEditorEle.textArea.nativeElement.focus();
     let selection = window.getSelection().getRangeAt(0);
     this.dialogRefTagSelection = this.dialog.open(TagSelectionComponent, { disableClose: false });
     this.dialogRefTagSelection.afterClosed().subscribe(result => {

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -84,7 +84,6 @@ export class TemplateManagerComponent implements OnInit {
     //this.getAllTemplates();
   }
   ngOnInit() {
-    console.log(this.image_upload_url)
     //get subscription to height of page from main layout component
     this.subscriptions.push(
       this.layoutSvc.getContentHeightEmitter().subscribe(height => {
@@ -229,6 +228,11 @@ export class TemplateManagerComponent implements OnInit {
 
   //Get Template model from the form group
   getTemplateFromForm(form: FormGroup) {
+    // form fields might not have the up-to-date content that the angular-editor has
+    form.controls['templateHTML'].setValue(this.angularEditorEle.textArea.nativeElement.innerHTML);
+    form.controls['templateText'].setValue(this.angularEditorEle.textArea.nativeElement.innerText);
+
+
     let formTemplate = new Template(form.value)
     let saveTemplate = new Template({
       template_uuid: form.controls['templateUUID'].value,
@@ -487,8 +491,7 @@ export class TemplateManagerComponent implements OnInit {
    * @param tag 
    */
   insertTag(selection, tagText: string) {
-    let newNode = document.createElement("span");
-    newNode.innerText = tagText;
+    let newNode = document.createTextNode(tagText);
     selection.insertNode(newNode);
     //newNode.insertAdjacentHTML("beforebegin", " ");
     //newNode.insertAdjacentHTML("afterend", " "); 

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -33,7 +33,7 @@ export class TemplateManagerComponent implements OnInit {
   dialogRefConfirm: MatDialogRef<ConfirmComponent>;
   dialogRefTagSelection: MatDialogRef<TagSelectionComponent>;
 
-  @ViewChild('angularEditor') angularEditor: ElementRef<AngularEditorComponent>;
+  @ViewChild('angularEditor') angularEditor: any;
 
   //Full template list variables
   search_input: string;

--- a/client/AdminUI/src/app/components/templates-page/templates-page.component.html
+++ b/client/AdminUI/src/app/components/templates-page/templates-page.component.html
@@ -53,7 +53,7 @@
       </ng-container>
 
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row class="table-row" *matRowDef="let row; columns: displayedColumns" (click)="editTemplate(row)"></mat-row>
+      <mat-row class="table-row cursor-pointer" *matRowDef="let row; columns: displayedColumns" (click)="editTemplate(row)"></mat-row>
     </mat-table>
   </div>
 </div>

--- a/client/AdminUI/src/app/components/templates-page/templates-page.component.scss
+++ b/client/AdminUI/src/app/components/templates-page/templates-page.component.scss
@@ -36,11 +36,6 @@ mat-form-field.mat-form-field {
     -moz-hyphens: auto;
     -webkit-hyphens: auto;
     hyphens: auto;
-  }
-
-.table-row:hover{
-    border-bottom: solid 1px;
-    border-top: solid 1px;  
 }
 
   

--- a/client/AdminUI/src/app/models/template.model.ts
+++ b/client/AdminUI/src/app/models/template.model.ts
@@ -89,3 +89,14 @@ export class TemplateImageModel{
     file_name : string
     file_url : string
 }
+
+
+/**
+ * An instance of a "Tag", a substitution token in a Template.
+ */
+export class TagModel {
+  tag: string;
+  description: string;
+  data_source: string;
+  tag_type: string;
+}

--- a/client/AdminUI/src/app/services/template-manager.service.ts
+++ b/client/AdminUI/src/app/services/template-manager.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 
-import { Template } from 'src/app/models/template.model';
+import { Template, TagModel } from 'src/app/models/template.model';
 
 const headers = {
   headers: new HttpHeaders().set('Content-Type', 'application/json'),
@@ -11,9 +11,26 @@ const headers = {
 
 @Injectable()
 export class TemplateManagerService {
-  constructor(private http: HttpClient) { }
 
-  //GET a list of all templates
+  public tags: TagModel[];
+
+
+  /**
+   * Constructor.
+   * @param http 
+   */
+  constructor(private http: HttpClient) { 
+
+    // load the tags collection up front
+    this.getAllTags().subscribe((result: TagModel[]) => {
+      this.tags = result;
+    });
+  }
+
+  /**
+   * GET a list of all templates
+   * @param retired 
+   */
   getAllTemplates(retired: boolean = false) {
     let url = `${environment.apiEndpoint}/api/v1/templates/`
     if (retired) {
@@ -22,22 +39,10 @@ export class TemplateManagerService {
     return this.http.get(url, headers);
   }
 
-  // getAllTemplates() {
-  //   return new Promise((resolve, reject) => {
-  //     this.http
-  //     .get('http://localhost:8000/api/v1/templates', headers)
-  //     .subscribe(
-  //       (success) => {
-  //         return success
-  //       },
-  //       (error) => {
-  //         return error
-  //       }
-  //     )
-  //   })
-  // }
-
-  //GET a single template using the provided temlpate_uuid
+  /**
+   * GET a single template using the provided temlpate_uuid
+   * @param uuid 
+   */
   getTemplate(uuid: string) {
     return new Promise((resolve, reject) => {
       this.http
@@ -55,7 +60,10 @@ export class TemplateManagerService {
     });
   }
 
-  //POST a new template
+  /**
+   * POST a new template
+   * @param template 
+   */
   saveNewTemplate(template: Template) {
     return new Promise((resolve, reject) => {
       this.http
@@ -72,7 +80,11 @@ export class TemplateManagerService {
         );
     });
   }
-  //PATCH an existing template with partial data
+
+  /**
+   * PATCH an existing template with partial data
+   * @param template 
+   */
   updateTemplate(template: Template) {
     return new Promise((resolve, reject) => {
       this.http
@@ -89,6 +101,11 @@ export class TemplateManagerService {
         );
     });
   }
+
+  /**
+   * 
+   * @param template 
+   */
   deleteTemplate(template: Template) {
     return new Promise((resolve, reject) => {
       this.http
@@ -104,8 +121,18 @@ export class TemplateManagerService {
     })
   }
 
+  /**
+   * 
+   * @param template 
+   */
   stopTemplate(template: Template) {
     return this.http.get(`${environment.apiEndpoint}/api/v1/template/stop/${template.template_uuid}/`);
   }
 
+  /**
+   * Gets a list of all known Tags
+   */
+  getAllTags() {
+    return this.http.get(`${environment.apiEndpoint}/api/v1/tags`);
+  }
 }

--- a/client/AdminUI/src/styles.scss
+++ b/client/AdminUI/src/styles.scss
@@ -337,8 +337,12 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
   color:  $light-text !important;
 }
 
-.mat-row:hover {
+.mat-row:hover, table.table-1 tr:hover {
   background-color: #eeeeee;
+}
+
+table.table-1 td {
+  padding: .3rem;
 }
 
 .cursor-pointer {

--- a/client/AdminUI/src/styles.scss
+++ b/client/AdminUI/src/styles.scss
@@ -346,7 +346,7 @@ table.table-1 td {
 }
 
 .cursor-pointer {
-  cursor: pointer;
+  cursor: pointer !important;
 }
 
 .header-logo-background{


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

Added a dialog that displays all 'tags'.  When the user selects a tag from the dialog, it is inserted into the content of the angular-editor component.  
The button to launch the dialog has been integrated into the angular-editor by inserting custom markup into the DOM.  
In cases where tags have been inserted into the Template markup, the form control is not aware of those changes.  At the time of saving the form, the form controls are refreshed from the angular-editor component.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
