### PR TITLE
Feature/cpa 267

### DIFF
--- a/controller/src/notifications/management/commands/send_reports_emails.py
+++ b/controller/src/notifications/management/commands/send_reports_emails.py
@@ -5,13 +5,21 @@ from typing import Any
 from django.core.management.base import BaseCommand
 
 # Local Libraries
+from api.models.subscription_models import SubscriptionModel, validate_subscription
 from notifications.views import ReportsEmailSender
+from api.utils.db_utils import get_list
 
 
 class Command(BaseCommand):
     help_text = "Sends reports emails"
 
     def handle(self, *args: Any, **options: Any) -> None:
+        parameters = {"archived": {"$in": [False, None]}}
+        subscription_list = get_list(
+            parameters, "subscription", SubscriptionModel, validate_subscription
+        )
+        subscription = subscription_list[0]
+
         message_type = "quarterly_report"
-        sender = ReportsEmailSender(message_type)
+        sender = ReportsEmailSender(subscription, message_type)
         sender.send()

--- a/controller/src/notifications/management/commands/send_reports_emails.py
+++ b/controller/src/notifications/management/commands/send_reports_emails.py
@@ -12,7 +12,6 @@ class Command(BaseCommand):
     help_text = "Sends reports emails"
 
     def handle(self, *args: Any, **options: Any) -> None:
-        recipients = ["test@example.com", "text2@example.com"]
         message_type = "quarterly_report"
-        sender = ReportsEmailSender(recipients, message_type)
+        sender = ReportsEmailSender(message_type)
         sender.send()

--- a/controller/src/notifications/views.py
+++ b/controller/src/notifications/views.py
@@ -20,7 +20,8 @@ from api.models.subscription_models import SubscriptionModel, validate_subscript
 
 
 class ReportsEmailSender:
-    def __init__(self, message_type: str):
+    def __init__(self, subscription, message_type: str):
+        self.subscription = subscription
         self.message_type = message_type
 
     def get_context_data(self, first_name, last_name):
@@ -43,14 +44,13 @@ class ReportsEmailSender:
         subscription_list = get_list(
             parameters, "subscription", SubscriptionModel, validate_subscription
         )
-        subscription = subscription_list[0]
 
         # pull subscription data
-        subscription_uuid = subscription.get("subscription_uuid")
-        recipient = subscription.get("primary_contact").get("email")
-        recipient_copy = subscription.get("dhs_primary_contact").get("email")
-        first_name = subscription.get("primary_contact").get("first_name")
-        last_name = subscription.get("primary_contact").get("last_name")
+        subscription_uuid = self.subscription.get("subscription_uuid")
+        recipient = self.subscription.get("primary_contact").get("email")
+        recipient_copy = self.subscription.get("dhs_primary_contact").get("email")
+        first_name = self.subscription.get("primary_contact").get("first_name")
+        last_name = self.subscription.get("primary_contact").get("last_name")
 
         # pass context to email templates
         context = self.get_context_data(first_name, last_name)

--- a/controller/src/notifications/views.py
+++ b/controller/src/notifications/views.py
@@ -16,7 +16,6 @@ from weasyprint import HTML
 # Local Libraries
 from notifications.utils import get_notification
 from api.utils.db_utils import get_list
-from api.models.subscription_models import SubscriptionModel, validate_subscription
 
 
 class ReportsEmailSender:
@@ -39,11 +38,6 @@ class ReportsEmailSender:
 
     def send(self):
         subject, path = get_notification(self.message_type)
-        # get subscription
-        parameters = {"archived": {"$in": [False, None]}}
-        subscription_list = get_list(
-            parameters, "subscription", SubscriptionModel, validate_subscription
-        )
 
         # pull subscription data
         subscription_uuid = self.subscription.get("subscription_uuid")


### PR DESCRIPTION
Update notification email view to include a bcc and single primary contact as recipients

## 🗣 Description

added dhs and primary contact as the recipients and bcc from each subscription. added a param to pass in subscription as opposed to pulling it from within the view

## 💭 Motivation and Context

Per requirements, updated the view to have a primary contact as a recipient and dhs contact as a bcc.

## 🧪 Testing

Test ran using `make send_emails`

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
