### PR TITLE
Removed xScaleMin and yScaleMin from chart

### DIFF
--- a/client/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
+++ b/client/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
@@ -18,7 +18,6 @@
           [yAxis]="chart.showYAxis"
           [showYAxisLabel]="chart.showYAxisLabel"
           [yAxisLabel]="chart.yAxisLabel"
-          [yScaleMin]=0
           [yAxisTickFormatting]="axisFormat"
           [legend]="chart.showLegend"
           [legendPosition]="chart.legendPosition"
@@ -35,7 +34,6 @@
           [scheme]="chartSent.colorScheme"
           [gradient]="chartSent.gradient"
           [xAxis]="chartSent.showXAxis"
-          [xScaleMin]=0
           [yAxis]="chartSent.showYAxis"
           [legend]="chartSent.showLegend"
           [showXAxisLabel]="chartSent.showXAxisLabel"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

The ngx-charts documentation refers to these properties, but the Angular compile throws errors.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
