### PR TITLE
feature: cpa-318

### DIFF
--- a/controller/src/api/utils/subscription/actions.py
+++ b/controller/src/api/utils/subscription/actions.py
@@ -136,7 +136,7 @@ def start_subscription(data=None, subscription_uuid=None):
         )
 
     # Schedule client side reports emails
-    if settings.DEBUG:
+    if not settings.DEBUG:
         tasks = create_scheduled_email_tasks(response)
         subscription["tasks"] = tasks
 

--- a/controller/src/api/utils/subscription/actions.py
+++ b/controller/src/api/utils/subscription/actions.py
@@ -136,7 +136,7 @@ def start_subscription(data=None, subscription_uuid=None):
         )
 
     # Schedule client side reports emails
-    if not settings.DEBUG:
+    if settings.DEBUG:
         tasks = create_scheduled_email_tasks(response)
         subscription["tasks"] = tasks
 

--- a/controller/src/api/utils/subscription/subscriptions.py
+++ b/controller/src/api/utils/subscription/subscriptions.py
@@ -122,7 +122,7 @@ def create_scheduled_email_tasks(created_response):
     for message_type, send_date in message_types.items():
         try:
             task = email_subscription_report.apply_async(
-                args=[subscription_uuid, message_type], eta=send_date
+                args=[subscription_uuid, message_type, send_date], eta=send_date
             )
             context.append({"task_uuid": task.id, "message_type": message_type})
         except task.OperationalError as exc:

--- a/controller/src/api/utils/subscription/subscriptions.py
+++ b/controller/src/api/utils/subscription/subscriptions.py
@@ -122,7 +122,9 @@ def create_scheduled_email_tasks(created_response):
     for message_type, send_date in message_types.items():
         try:
             task = email_subscription_report.apply_async(
-                args=[subscription_uuid, message_type, send_date], eta=send_date
+                args=[subscription_uuid, message_type, send_date],
+                eta=send_date,
+                retry=True,
             )
             context.append({"task_uuid": task.id, "message_type": message_type})
         except task.OperationalError as exc:

--- a/controller/src/api/utils/subscription/subscriptions.py
+++ b/controller/src/api/utils/subscription/subscriptions.py
@@ -127,4 +127,5 @@ def create_scheduled_email_tasks(created_response):
             context.append({"task_uuid": task.id, "message_type": message_type})
         except task.OperationalError as exc:
             logger.exception("Subscription task raised: %r", exc)
+
     return context

--- a/controller/src/tasks/tasks.py
+++ b/controller/src/tasks/tasks.py
@@ -1,11 +1,11 @@
 # Standard Python Libraries
 import os
+from datetime import timedelta
 
 from api.manager import CampaignManager
 from api.models.subscription_models import SubscriptionModel, validate_subscription
 from celery import Celery, shared_task
 from celery.schedules import crontab
-from config.celery import app
 
 # Local Libraries
 from api.models.subscription_models import SubscriptionModel, validate_subscription
@@ -18,9 +18,9 @@ campaign_manager = CampaignManager()
 
 
 @shared_task
-def email_subscription_report(subscription_uuid, message_type):
+def email_subscription_report(subscription_uuid, message_type, send_date):
     """
-    Pull final subscription report
+    Schedule periodic subscription report emails
     """
     subscription = get_single(
         subscription_uuid, "subscription", SubscriptionModel, validate_subscription
@@ -30,16 +30,72 @@ def email_subscription_report(subscription_uuid, message_type):
     sender = ReportsEmailSender(subscription, message_type)
     sender.send()
 
-    # Set GoPhish Campaign to Complete for Cycle Reports
-    if message_type == "cycle_report":
+    # Schedule next task
+    if message_type == "monthly_report":
+        next_send_date = send_date + timedelta(days=30)
+    elif message_type == "cycle_report":
+        # Set GoPhish Campaign to Complete for Cycle Reports
         campaigns = subscription.get("gophish_campaign_list")
         [
             campaign_manager.complete_campaign(campaign_id=campaign.get("campaign_id"))
             for campaign in campaigns
         ]
 
+        # Schedule next task
+        next_send_date = send_date + timedelta(days=90)
+    elif message_type == "yearly_report":
+        next_send_date = send_date + timedelta(days=365)
+
     context = {
         "subscription_uuid": subscription_uuid,
+    }
+
+    return context
+
+
+@shared_task
+def email_subscription_monthly(subscription):
+    """
+    schedule the next monthly subscription report email
+    """
+    # Send email
+    sender = ReportsEmailSender(subscription, "monthly_report")
+    sender.send()
+
+    context = {
+        "subscription_uuid": subscription.get("subscription_uuid"),
+    }
+
+    return context
+
+
+@shared_task
+def email_subscription_cycle(subscription):
+    """
+    schedule the next subscription cycle report email
+    """
+    # Send email
+    sender = ReportsEmailSender(subscription, "cycle_report")
+    sender.send()
+
+    context = {
+        "subscription_uuid": subscription.get("subscription_uuid"),
+    }
+
+    return context
+
+
+@shared_task
+def email_subscription_yearly(subscription):
+    """
+    schedule the next yearly subscription report email
+    """
+    # Send email
+    sender = ReportsEmailSender(subscription, "yearly_report")
+    sender.send()
+
+    context = {
+        "subscription_uuid": subscription.get("subscription_uuid"),
     }
 
     return context

--- a/controller/src/tasks/tasks.py
+++ b/controller/src/tasks/tasks.py
@@ -33,6 +33,9 @@ def email_subscription_report(subscription_uuid, message_type, send_date):
     # Schedule next task
     if message_type == "monthly_report":
         next_send_date = send_date + timedelta(days=30)
+        task = email_subscription_monthly.apply_async(
+            args=[subscription], eta=next_send_date
+        )
     elif message_type == "cycle_report":
         # Set GoPhish Campaign to Complete for Cycle Reports
         campaigns = subscription.get("gophish_campaign_list")
@@ -43,8 +46,14 @@ def email_subscription_report(subscription_uuid, message_type, send_date):
 
         # Schedule next task
         next_send_date = send_date + timedelta(days=90)
+        task = email_subscription_cycle.apply_async(
+            args=[subscription], eta=next_send_date
+        )
     elif message_type == "yearly_report":
         next_send_date = send_date + timedelta(days=365)
+        task = email_subscription_yearly.apply_async(
+            args=[subscription], eta=next_send_date
+        )
 
     context = {
         "subscription_uuid": subscription_uuid,

--- a/controller/src/tasks/tasks.py
+++ b/controller/src/tasks/tasks.py
@@ -55,6 +55,10 @@ def email_subscription_report(subscription_uuid, message_type, send_date):
             args=[subscription], eta=next_send_date
         )
 
+    next_task = {"task_uuid": task.id, "message_type": message_type}
+    if subscription.get("tasks"):
+        subscription.get("tasks").append(next_task)
+
     context = {
         "subscription_uuid": subscription_uuid,
     }

--- a/controller/src/tasks/views.py
+++ b/controller/src/tasks/views.py
@@ -75,7 +75,7 @@ class TaskListView(APIView):
 
         try:
             task = email_subscription_report.apply_async(
-                args=[subscription_uuid, message_type], eta=send_date
+                args=[subscription_uuid, message_type, send_date], eta=send_date
             )
         except task.OperationalError as exc:
             logger.exception("Subscription task raised: %r", exc)

--- a/controller/src/tasks/views.py
+++ b/controller/src/tasks/views.py
@@ -75,7 +75,9 @@ class TaskListView(APIView):
 
         try:
             task = email_subscription_report.apply_async(
-                args=[subscription_uuid, message_type, send_date], eta=send_date
+                args=[subscription_uuid, message_type, send_date],
+                eta=send_date,
+                retry=True,
             )
         except task.OperationalError as exc:
             logger.exception("Subscription task raised: %r", exc)


### PR DESCRIPTION
Create scheduled subtasks to launch succeeding subscription reports every month, cycle and year

## 🗣 Description

Create scheduled subtasks to launch succeeding subscription reports every month, cycle and year
Add future tasks' ids to subscription model instance
force task retry in case of failure

## 💭 Motivation and Context

to launch repeating tasks per subscription until stopped or cancelled

## 🧪 Testing

Sucessfully test ran locally using telnet to access alternative threads for debugging

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
