### PR TITLE
feaure: CPA-357 Schedule next Sub Cycle

### DIFF
--- a/controller/src/api/utils/subscription/actions.py
+++ b/controller/src/api/utils/subscription/actions.py
@@ -137,9 +137,11 @@ def start_subscription(data=None, subscription_uuid=None):
 
     # Schedule client side reports emails
     if not settings.DEBUG:
-        email_tasks = create_scheduled_email_tasks(response)
+        tasks = create_scheduled_email_tasks(response)
         cycle_task = create_scheduled_cycle_tasks(response)
-        subscription["tasks"] = email_tasks
+
+        tasks.append(cycle_task)
+        subscription["tasks"] = tasks
     else:
         subscription["tasks"] = []
 

--- a/controller/src/api/utils/subscription/actions.py
+++ b/controller/src/api/utils/subscription/actions.py
@@ -19,6 +19,7 @@ from api.utils.subscription.subscriptions import (
     get_subscription_cycles,
     get_subscription_status,
     send_start_notification,
+    create_scheduled_cycle_tasks,
 )
 from api.utils.subscription.targets import batch_targets
 from api.utils.subscription.template_selector import personalize_template_batch
@@ -136,8 +137,9 @@ def start_subscription(data=None, subscription_uuid=None):
 
     # Schedule client side reports emails
     if not settings.DEBUG:
-        tasks = create_scheduled_email_tasks(response)
-        subscription["tasks"] = tasks
+        email_tasks = create_scheduled_email_tasks(response)
+        cycle_task = create_scheduled_cycle_tasks(response)
+        subscription["tasks"] = email_tasks
     else:
         subscription["tasks"] = []
 

--- a/controller/src/api/utils/subscription/actions.py
+++ b/controller/src/api/utils/subscription/actions.py
@@ -10,7 +10,7 @@ from api.models.subscription_models import SubscriptionModel, validate_subscript
 from api.serializers.subscriptions_serializers import SubscriptionPatchSerializer
 from api.utils import db_utils as db
 from api.utils.customer.customers import get_customer
-from api.utils.subscription.campaigns import generate_campaigns
+from api.utils.subscription.campaigns import generate_campaigns, stop_campaign
 from api.utils.subscription.subscriptions import (
     calculate_subscription_start_end_date,
     create_scheduled_email_tasks,
@@ -26,7 +26,11 @@ from api.utils.template.templates import deception_level
 from celery.task.control import revoke
 from django.conf import settings
 
+
 logger = logging.getLogger(__name__)
+
+# GoPhish Campaign Manager
+campaign_manager = CampaignManager()
 
 
 def start_subscription(data=None, subscription_uuid=None):
@@ -150,35 +154,126 @@ def start_subscription(data=None, subscription_uuid=None):
     return response
 
 
+def new_subscription_cycle(subscription_uuid):
+    """
+    Returns a subscription from database.
+
+    Parameters:
+        subscription_uuid (str): uuid of subscription to restart.
+
+
+    Returns:
+        dict: returns response of updated subscription from database.
+    """
+    subscription = get_subscription(subscription_uuid)
+
+    # Stop Campaigns
+    updated_campaigns = list(map(stop_campaign, subscription["gophish_campaign_list"]))
+
+    # calculate start and end date to subscription
+    start_date, end_date = calculate_subscription_start_end_date(
+        subscription.get("start_date")
+    )
+
+    # Get details for the customer that is attached to the subscription
+    customer = get_customer(subscription["customer_uuid"])
+
+    # Create the needed subscription levels to fill.
+    sub_levels = {
+        "high": {
+            "start_date": start_date,
+            "end_date": end_date,
+            "template_targets": {},
+            "template_uuids": [],
+            "personalized_templates": [],
+            "targets": [],
+            "deception_level": deception_level.get("high"),
+        },
+        "moderate": {
+            "start_date": start_date,
+            "end_date": end_date,
+            "template_targets": {},
+            "template_uuids": [],
+            "personalized_templates": [],
+            "targets": [],
+            "deception_level": deception_level.get("moderate"),
+        },
+        "low": {
+            "start_date": start_date,
+            "end_date": end_date,
+            "template_targets": {},
+            "template_uuids": [],
+            "personalized_templates": [],
+            "targets": [],
+            "deception_level": deception_level.get("low"),
+        },
+    }
+
+    logging.info(f"subscription_name={subscription['name']}")
+
+    # get personalized and selected template_uuids
+    sub_levels = personalize_template_batch(
+        customer, subscription, sub_levels, new_cycle=True
+    )
+
+    # get targets assigned to each group
+    sub_levels = batch_targets(subscription, sub_levels)
+
+    # Get all Landing pages or default
+    # This is currently selecting the default page on creation.
+    # landing_template_list = get_list({"template_type": "Landing"}, "template", TemplateModel, validate_template)
+    landing_page = "Phished"
+
+    # subscription["gophish_campaign_list"] = generate_campaigns(
+    #     subscription, landing_page, sub_levels
+    # )
+    selected_templates = []
+    for v in sub_levels.values():
+        selected_templates.extend(list(v["template_targets"].keys()))
+    subscription["templates_selected_uuid_list"] = selected_templates
+
+    subscription["end_date"] = end_date.strftime("%Y-%m-%dT%H:%M:%S")
+    subscription["status"] = get_subscription_status(start_date)
+    subscription["cycles"].append(
+        get_subscription_cycles(
+            subscription["gophish_campaign_list"], start_date, end_date
+        )[0]
+    )
+
+    response = db.update_single(
+        subscription_uuid,
+        subscription,
+        "subscription",
+        SubscriptionModel,
+        validate_subscription,
+    )
+
+    # Schedule client side reports emails
+    if not settings.DEBUG:
+        tasks = create_scheduled_email_tasks(response)
+        subscription["tasks"] = tasks
+    else:
+        subscription["tasks"] = []
+
+    db.update_single(
+        response["subscription_uuid"],
+        {"tasks": subscription["tasks"]},
+        "subscription",
+        SubscriptionModel,
+        validate_subscription,
+    )
+
+    send_start_notification(subscription, start_date)
+
+    return response
+
+
 def stop_subscription(subscription):
     """
     Stops a given subscription.
 
     Returns updated subscription.
     """
-    campaign_manager = CampaignManager()
-
-    def stop_campaign(campaign):
-        """
-        Stops a given campaign.
-
-        Delete Campaign
-
-        Delete Template
-
-        Returns updated Campaign
-        """
-        campaign_manager.complete_campaign(campaign_id=campaign["campaign_id"])
-        campaign["status"] = "stopped"
-        campaign["completed_date"] = datetime.now()
-        # Delete Campaign
-        campaign_manager.delete_campaign(campaign_id=campaign["campaign_id"])
-        # Delete Templates
-        campaign_manager.delete(
-            "email_template", template_id=campaign["email_template_id"]
-        )
-
-        return campaign
 
     # Stop Campaigns
     updated_campaigns = list(map(stop_campaign, subscription["gophish_campaign_list"]))

--- a/controller/src/api/utils/subscription/campaigns.py
+++ b/controller/src/api/utils/subscription/campaigns.py
@@ -1,7 +1,7 @@
 """Subscription Campaigns."""
 
 # Standard Python Libraries
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 # Third-Party Libraries
@@ -98,6 +98,27 @@ def create_campaign(subscription, sub_level, landing_page):
         )
 
     return gophish_campaigns
+
+
+def stop_campaign(campaign):
+    """
+    Stops a given campaign.
+
+    Delete Campaign
+
+    Delete Template
+
+    Returns updated Campaign
+    """
+    campaign_manager.complete_campaign(campaign_id=campaign["campaign_id"])
+    campaign["status"] = "stopped"
+    campaign["completed_date"] = datetime.now()
+    # Delete Campaign
+    campaign_manager.delete_campaign(campaign_id=campaign["campaign_id"])
+    # Delete Templates
+    campaign_manager.delete("email_template", template_id=campaign["email_template_id"])
+
+    return campaign
 
 
 def __create_campaign(

--- a/controller/src/api/utils/subscription/subscriptions.py
+++ b/controller/src/api/utils/subscription/subscriptions.py
@@ -133,3 +133,19 @@ def create_scheduled_email_tasks(created_response):
             logger.exception("Subscription task raised: %r", exc)
 
     return context
+
+
+def create_scheduled_cycle_tasks(created_response):
+    subscription_uuid = created_response.get("subscription_uuid")
+    send_date = datetime.utcnow() + timedelta(days=90)
+
+    context = []
+    try:
+        task = start_subscription_cycle.apply_async(
+            args=[subscription_uuid], eta=send_date, retry=True,
+        )
+        context.append({"task_uuid": task.id, "message_type": message_type})
+    except task.OperationalError as exc:
+        logger.exception("Subscription task raised: %r", exc)
+
+    return context

--- a/controller/src/api/utils/subscription/template_selector.py
+++ b/controller/src/api/utils/subscription/template_selector.py
@@ -82,10 +82,21 @@ def personalize_templates(customer, subscription, templates, sub_levels: dict):
     return sub_levels
 
 
-def personalize_template_batch(customer, subscription, sub_levels: dict):
+def personalize_template_batch(
+    customer, subscription, sub_levels: dict, new_cycle=False
+):
     """Personalize_template_batch."""
     # Gets list of available email templates
     templates = get_email_templates()
+
+    # if new subscription cycle, exclude previously used templates
+    if new_cycle:
+        existing_templates = subscription.get("templates_selected_uuid_list")
+        templates = [
+            template
+            for template in templates
+            if template["template_uuid"] not in existing_templates
+        ]
 
     logger.info(f"Template Count = {len(templates)}")
 

--- a/controller/src/api/views/subscription_views.py
+++ b/controller/src/api/views/subscription_views.py
@@ -19,7 +19,10 @@ from api.serializers.subscriptions_serializers import (
     SubscriptionPostSerializer,
 )
 from api.utils.db_utils import delete_single, get_list, get_single, update_single
-from api.utils.subscription.actions import start_subscription, stop_subscription
+from api.utils.subscription.actions import (
+    start_subscription,
+    stop_subscription,
+)
 from celery.task.control import revoke
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema

--- a/controller/src/tasks/tasks.py
+++ b/controller/src/tasks/tasks.py
@@ -18,6 +18,15 @@ campaign_manager = CampaignManager()
 
 
 @shared_task
+def new_subscription_cycle(subscription):
+    subscription
+    context = {
+        "subscription_uuid": subscription.get("subscription_uuid"),
+    }
+    return context
+
+
+@shared_task
 def email_subscription_report(subscription_uuid, message_type, send_date):
     """
     Schedule periodic subscription report emails


### PR DESCRIPTION
Schedule the next subscription cycle

## 🗣 Description

Schedule the next subscription cycle on subscription start / restart. created a new subscription action for launching cycles.
Add logic to ensure templates aren't repeatedly used from previous cycle

## 💭 Motivation and Context
Need the ability to schedule the launch following subscriptions cycle

## 🧪 Testing
Successfully test ran tasks locally

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
