### PR TITLE
bug when retrieiving report of a stopped subscription

### DIFF
--- a/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription.component.html
+++ b/client/AdminUI/src/app/components/subscriptions/delete-subscription/delete-subscription.component.html
@@ -1,8 +1,10 @@
-<button
-  id="delete-subscription"
-  mat-raised-button
-  color="warn"
-  (click)="openDialog()"
+<button 
+  id="delete-subscription" 
+  mat-raised-button 
+  color="warn" 
+  (click)="openDialog()" 
+  [disabled]="subscription.status != 'stopped'" 
+  title="Subscription must be stopped before deleting"
 >
   Delete Subscription
 </button>


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->

When a subscription is completed, gophish is cleaned up. Templates, campaigns, groups. This causes an error on the reports that are going out to gophish to grab statistics.

This change instead grabs the statistics that are being copied into MongoDB from webhooks.

I also disabled the delete subscription button unless the subscription is stopped.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
UI tested.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
