### PR TITLE
Fix to the cycle reports template breakdown display

### DIFF
--- a/controller/src/reports/views.py
+++ b/controller/src/reports/views.py
@@ -443,6 +443,12 @@ class CycleReportsView(TemplateView):
                 "difference": difference
             })
 
+        templates_by_group = []
+        
+
+        templates_by_group.append([x for x in subscription_stats["campaign_results"] if x["deception_level"] == 1])
+        templates_by_group.append([x for x in subscription_stats["campaign_results"] if x["deception_level"] == 2])
+        templates_by_group.append([x for x in subscription_stats["campaign_results"] if x["deception_level"] == 3])
 
         context = {}
         context["dhs_contact_name"] = dhs_contact_name
@@ -461,6 +467,8 @@ class CycleReportsView(TemplateView):
         context["region_stats"] = region_stats
         context["subscription_stats"] = subscription_stats
         context["click_time_vs_report_time"] = click_time_vs_report_time
+        context["templates_by_group"] = templates_by_group
+
 
 
         return context

--- a/controller/src/static/css/cycle.css
+++ b/controller/src/static/css/cycle.css
@@ -31,6 +31,10 @@ body {
   page-break-after: always;
 }
 
+.template_pages {
+  page-break-after: always;
+}
+
 article:nth-of-type(n+2) {
   padding-top: 100px;
 }

--- a/controller/src/templates/reports/cycle.html
+++ b/controller/src/templates/reports/cycle.html
@@ -1093,12 +1093,22 @@
 
         <article id="pagefourteen"></article>
 
-        <article id="pageFifteen">
+        {% for group in templates_by_group %}
+        {% for campaign in group %}
+        <article class="template_pages">
             <div class="row">
                 <div class="col-12">
+                    {% if forloop.first %}   
+                    {% if forloop.parentloop.counter == 1 %}                 
                     <h3 id="dumbPhishTitle"><small class="font-weight-bold">Low Templates/Dumb Phish</small></h3>
-                    {% for campaign in subscription_stats.campaign_results %}
-                        {% if campaign.deception_level == 1 %}
+                    {% endif %}   
+                    {% if forloop.parentloop.counter == 2 %}                 
+                    <h3 id="dumbPhishTitle"><small class="font-weight-bold">Medium Templates/Moderate Phish</small></h3>
+                    {% endif %}   
+                    {% if forloop.parentloop.counter == 3 %}                 
+                    <h3 id="dumbPhishTitle"><small class="font-weight-bold">Difficult Templates/Spear Phish</small></h3>
+                    {% endif %}
+                    {% endif %}
                     <table id="dumbPhishTable">
                         <tr>
                             <td>Template Name&colon;</td>
@@ -1145,193 +1155,34 @@
                             {% endif %}
                         </tr>
                     </table>
-            <div class="row">
-                <div class="col-12">
-                    <div id="dumbPhishDetails">
-                        {% if campaign.template_details.subject %}
-                            <b>Subject&colon;</b> {{campaign.template_details.subject}}<br>
-                        {% else %}
-                            <b>Subject&colon;</b> N/A <br>
-                        {% endif %}
+                    <div class="row">
+                        <div class="col-12">
+                            <div>
+                                {% if campaign.template_details.subject %}
+                                    <b>Subject&colon;</b> {{campaign.template_details.subject}}<br>
+                                {% else %}
+                                    <b>Subject&colon;</b> N/A <br>
+                                {% endif %}
 
-                        {% if campaign.template_details.from_address %}
-                            <b>From&colon;</b> {{campaign.template_details.from_address}}<br>
-                        {% else %}
-                            <b>From&colon;</b> N/A <br>
-                        {% endif %}
-                        
-                        <b>Email Body&colon;</b>
-                        <div id="dumbEmailBody">
-                            {{campaign.template_details.html|safe}}
+                                {% if campaign.template_details.from_address %}
+                                    <b>From&colon;</b> {{campaign.template_details.from_address}}<br>
+                                {% else %}
+                                    <b>From&colon;</b> N/A <br>
+                                {% endif %}
+                                
+                                <b>Email Body&colon;</b>
+                                <div>
+                                    {{campaign.template_details.html|safe}}
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-            {% endif %}
-        {% endfor %}
-        </div>
-    </div>
         </article>
-
-        <article id="pageSixteen">
-            <div class="row">
-                <div class="col-12">
-                    <h3 id="mediumPhishTitle"><small class="font-weight-bold">Medium Templates/Moderate Phish</small></h3>
-                    {% for campaign in subscription_stats.campaign_results %}
-                        {% if campaign.deception_level == 2 %}
-                    <table id="dumbPhishTable">
-                        <tr>
-                            <td>Template Name&colon;</td>
-                            <td>{{campaign.template_details.name}}</td>
-                        </tr>
-                        <tr>
-                            <td>Deception Level&colon;</td>
-                            <td>{{campaign.deception_level}}</td>
-                        </tr>
-                        <tr>
-                            <td>Percent of Campaigns&colon;</td>
-                            <td>{{campaign.campaign_stats.percent_of_campaigns}}&percnt;</td>
-                        </tr>
-                        <tr>
-                            <td>Total Sent&colon;</td>
-                            {% if campaign.campaign_stats.sent.count %}
-                                <td>{{campaign.campaign_stats.sent.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                        <tr>
-                            <td>Clicked&colon;</td>
-                            {% if campaign.campaign_stats.clicked.count %}
-                                <td>{{campaign.campaign_stats.clicked.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                        <tr>
-                            <td>Submitted Data&colon;</td>
-                            {% if campaign.campaign_stats.submitted.count %}
-                                <td>{{campaign.campaign_stats.submitted.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                        <tr>
-                            <td>Reported&colon;</td>
-                            {% if campaign.campaign_stats.reported.count %}
-                                <td>{{campaign.campaign_stats.reported.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                    </table>
-            <div class="row">
-                <div class="col-12">
-                    <div id="dumbPhishDetails">
-                        {% if campaign.template_details.subject %}
-                            <b>Subject&colon;</b> {{campaign.template_details.subject}}<br>
-                        {% else %}
-                            <b>Subject&colon;</b> N/A <br>
-                        {% endif %}
-
-                        {% if campaign.template_details.from_address %}
-                            <b>From&colon;</b> {{campaign.template_details.from_address}}<br>
-                        {% else %}
-                            <b>From&colon;</b> N/A <br>
-                        {% endif %}
-                        
-                        <b>Email Body&colon;</b>
-                        <div id="dumbEmailBody">
-                            {{campaign.template_details.html|safe}}
-                        </div>
-                    </div>
-                </div>
-            </div>
-            {% endif %}
         {% endfor %}
-        </div>
-    </div>
-        </article>
-
-        <article id="pageSeventeen">
-            <div class="row">
-                <div class="col-12">
-                    <h3 id="hardPhishTitle"><small class="font-weight-bold">Difficult Templates/Spear Phish</small></h3>
-                    {% for campaign in subscription_stats.campaign_results %}
-                        {% if campaign.deception_level == 3 %}
-                    <table id="dumbPhishTable">
-                        <tr>
-                            <td>Template Name&colon;</td>
-                            <td>{{campaign.template_details.name}}</td>
-                        </tr>
-                        <tr>
-                            <td>Deception Level&colon;</td>
-                            <td>{{campaign.deception_level}}</td>
-                        </tr>
-                        <tr>
-                            <td>Percent of Campaigns&colon;</td>
-                            <td>{{campaign.campaign_stats.percent_of_campaigns}}&percnt;</td>
-                        </tr>
-                        <tr>
-                            <td>Total Sent&colon;</td>
-                            {% if campaign.campaign_stats.sent.count %}
-                                <td>{{campaign.campaign_stats.sent.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                        <tr>
-                            <td>Clicked&colon;</td>
-                            {% if campaign.campaign_stats.clicked.count %}
-                                <td>{{campaign.campaign_stats.clicked.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                        <tr>
-                            <td>Submitted Data&colon;</td>
-                            {% if campaign.campaign_stats.submitted.count %}
-                                <td>{{campaign.campaign_stats.submitted.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                        <tr>
-                            <td>Reported&colon;</td>
-                            {% if campaign.campaign_stats.reported.count %}
-                                <td>{{campaign.campaign_stats.reported.count}} </td>
-                            {% else %}
-                                <td> 0 </td>
-                            {% endif %}
-                        </tr>
-                    </table>
-            <div class="row">
-                <div class="col-12">
-                    <div id="dumbPhishDetails">
-                        {% if campaign.template_details.subject %}
-                            <b>Subject&colon;</b> {{campaign.template_details.subject}}<br>
-                        {% else %}
-                            <b>Subject&colon;</b> N/A <br>
-                        {% endif %}
-
-                        {% if campaign.template_details.from_address %}
-                            <b>From&colon;</b> {{campaign.template_details.from_address}}<br>
-                        {% else %}
-                            <b>From&colon;</b> N/A <br>
-                        {% endif %}
-                        
-                        <b>Email Body&colon;</b>
-                        <div id="dumbEmailBody">
-                            {{campaign.template_details.html|safe}}
-                        </div>
-                    </div>
-                </div>
-            </div>
-            {% endif %}
         {% endfor %}
-        </div>
-    </div>
-        </article>
+
 
     </body>
 


### PR DESCRIPTION
## 🗣 Description

Change the way template breakdown are displayed at the end of the cycle report.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
