### PR TITLE
Bug/nwd 305

### DIFF
--- a/client/AdminUI/src/app/app.module.ts
+++ b/client/AdminUI/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { AuthAppendInterceptor } from './helper/AuthAppendInterceptor'
 import { UnauthorizedInterceptor } from './helper/UnauthorizedInterceptor'
 import { DhsPocComponent } from './components/user-admin/dhs-poc/dhs-poc.component';
 import { DhsPocDetailComponent } from './components/user-admin/dhs-poc/dhs-poc-detail.component';
+import { InputTrimDirective } from './helper/input-trim.directive';
 
 export function app_Init(settingsHttpService: SettingsHttpService) {
   return () => settingsHttpService.initializeApp()
@@ -104,6 +105,7 @@ export function app_Init(settingsHttpService: SettingsHttpService) {
     SvgTimelineComponent,
     DhsPocComponent,
     DhsPocDetailComponent,
+    InputTrimDirective,
   ],
   imports: [
     BrowserModule,

--- a/client/AdminUI/src/app/components/contacts/add-contact-dialog/add-contact-dialog.component.html
+++ b/client/AdminUI/src/app/components/contacts/add-contact-dialog/add-contact-dialog.component.html
@@ -6,7 +6,7 @@
     <mat-form-field appearance="outline">
       <mat-label>First Name</mat-label>
       <input
-        matInput
+        matInput trim="blur"
         type="text"
         formControlName="first_name"
         placeholder="First Name"
@@ -18,6 +18,7 @@
       <mat-label>Last Name</mat-label>
       <input
         matInput
+        trim="blur"
         type="text"
         formControlName="last_name"
         placeholder="Last Name"
@@ -30,6 +31,7 @@
     <mat-label>Position</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       formControlName="title"
       placeholder="Position"
@@ -51,6 +53,7 @@
     <mat-label>Office Phone Number</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       formControlName="office_phone"
       placeholder="(222)222-2222"
@@ -62,6 +65,7 @@
     <mat-label>Mobile Phone Number</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       formControlName="mobile_phone"
       placeholder="(222)222-2222"
@@ -73,6 +77,7 @@
     <mat-label>Email</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       formControlName="email"
       placeholder="Email@exmaple.com"
@@ -84,6 +89,7 @@
     <mat-label>Notes</mat-label>
     <textarea
       matInput
+      trim="blur"
       cdkTextareaAutosize
       #autosize="cdkTextareaAutosize"
       formControlName="notes"

--- a/client/AdminUI/src/app/components/contacts/dialogues/add-contact-dialog.html
+++ b/client/AdminUI/src/app/components/contacts/dialogues/add-contact-dialog.html
@@ -6,6 +6,7 @@
       <mat-label>First Name</mat-label>
       <input
         matInput
+        trim="blur"
         type="text"
         [(ngModel)]="addContactFirstName"
         placeholder="First Name"
@@ -15,6 +16,7 @@
       <mat-label>Last Name</mat-label>
       <input
         matInput
+        trim="blur"
         type="text"
         [(ngModel)]="addContactLastName"
         placeholder="Last Name"
@@ -50,9 +52,10 @@
     />
   </mat-form-field>
   <mat-form-field appearance="outline">
-    <mat-label>Email</mat-label>
+    <mat-label>Email!</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       [(ngModel)]="addContactEmail"
       placeholder="Email@exmaple.com"

--- a/client/AdminUI/src/app/components/contacts/dialogues/add-contact-dialog.html
+++ b/client/AdminUI/src/app/components/contacts/dialogues/add-contact-dialog.html
@@ -52,7 +52,7 @@
     />
   </mat-form-field>
   <mat-form-field appearance="outline">
-    <mat-label>Email!</mat-label>
+    <mat-label>Email</mat-label>
     <input
       matInput
       trim="blur"

--- a/client/AdminUI/src/app/components/contacts/view-contact-dialog/view-contact-dialog.component.html
+++ b/client/AdminUI/src/app/components/contacts/view-contact-dialog/view-contact-dialog.component.html
@@ -7,6 +7,7 @@
         <mat-label>First Name</mat-label>
         <input
           matInput
+          trim="blur"
           type="text"
           [(ngModel)]="data.first_name"
           formControlName="first_name"
@@ -19,6 +20,7 @@
         <mat-label>Last Name</mat-label>
         <input
           matInput
+          trim="blur"
           type="text"
           [(ngModel)]="data.last_name"
           formControlName="last_name"
@@ -31,6 +33,7 @@
     <mat-label>Title</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       [(ngModel)]="data.title"
       formControlName="title"
@@ -41,6 +44,7 @@
     <mat-label>Office Phone Number</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       [(ngModel)]="data.office_phone"
       formControlName="office_phone"
@@ -51,6 +55,7 @@
     <mat-label>Mobile Phone Number</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       [(ngModel)]="data.mobile_phone"
       formControlName="mobile_phone"
@@ -61,6 +66,7 @@
     <mat-label>Email</mat-label>
     <input
       matInput
+      trim="blur"
       type="email"
       [(ngModel)]="data.email"
       formControlName="email"
@@ -71,6 +77,7 @@
     <mat-label>Notes</mat-label>
     <input
       matInput
+      trim="blur"
       type="text"
       [(ngModel)]="data.notes"
       formControlName="notes"

--- a/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
+++ b/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
@@ -11,7 +11,7 @@
             <div class="d-flex flex-row">
                 <mat-form-field appearance="outline" class="flex-grow-1" [formGroup]="customerFormGroup">
                     <mat-label>Customer Name*</mat-label>
-                    <input type="text" matInput placeholder="Customer/Organization Name" formControlName="customerName"
+                    <input type="text" trim="blur" matInput placeholder="Customer/Organization Name" formControlName="customerName"
                         [errorStateMatcher]="matchCustomerName">
                     <mat-error *ngIf="customerFormGroup.controls.customerName.hasError('required')">
                         Customer/Organization name is <strong>required</strong>
@@ -23,7 +23,7 @@
                 <mat-form-field appearance="outline" class="flex-grow-4" style="padding-bottom:10px"
                     [formGroup]="customerFormGroup">
                     <mat-label>Customer Identifier*</mat-label>
-                    <input type="text" matInput placeholder="Customer/Organization Identifier"
+                    <input type="text" trim="blur" matInput placeholder="Customer/Organization Identifier"
                         formControlName="customerIdentifier" [errorStateMatcher]="matchCustomerIdentifier">
                     <mat-hint align="start"><strong>Short acronym or letters to identify the customer</strong>
                     </mat-hint>
@@ -60,7 +60,7 @@
             <div class="d-flex flex-row">
                 <mat-form-field appearance="outline" class="flex-grow-1" [formGroup]="customerFormGroup">
                     <mat-label>Address 1*</mat-label>
-                    <input type="text" matInput placeholder="Address 1" formControlName="address1"
+                    <input type="text" trim="blur" matInput placeholder="Address 1" formControlName="address1"
                         [errorStateMatcher]="matchAddress1">
                     <mat-error *ngIf="customerFormGroup.controls.address1.hasError('required')">
                         Address 1 is <strong>required</strong>
@@ -73,13 +73,13 @@
             <div class="d-flex flex-row">
                 <mat-form-field appearance="outline" class="flex-grow-1" [formGroup]="customerFormGroup">
                     <mat-label>Address 2</mat-label>
-                    <input type="text" matInput placeholder="Address 2" formControlName="address2">
+                    <input type="text" trim="blur" matInput placeholder="Address 2" formControlName="address2">
                 </mat-form-field>
             </div>
             <div class="d-flex flex-row">
                 <mat-form-field appearance="outline" class="flex-grow-1" [formGroup]="customerFormGroup">
                     <mat-label>City*</mat-label>
-                    <input type="text" matInput placeholder="City" formControlName="city"
+                    <input type="text" trim="blur" matInput placeholder="City" formControlName="city"
                         [errorStateMatcher]="matchCity">
                     <mat-error *ngIf="customerFormGroup.controls.city.hasError('required')">
                         City is <strong>required</strong>
@@ -90,7 +90,7 @@
                 </mat-form-field>
                 <mat-form-field appearance="outline" class="flex-grow-2" [formGroup]="customerFormGroup">
                     <mat-label>State*</mat-label>
-                    <input type="text" matInput placeholder="State" formControlName="state"
+                    <input type="text" trim="blur" matInput placeholder="State" formControlName="state"
                         [errorStateMatcher]="matchState">
                     <mat-error *ngIf="customerFormGroup.controls.state.hasError('required')">
                         State is <strong>required</strong>
@@ -102,7 +102,7 @@
                 <mat-form-field appearance="outline" class="flex-shrink-5" [formGroup]="customerFormGroup"
                     [style.width.px]=80>
                     <mat-label>Zip*</mat-label>
-                    <input type="text" matInput placeholder="Zip" formControlName="zip" [errorStateMatcher]="matchZip">
+                    <input type="text" trim="blur" matInput placeholder="Zip" formControlName="zip" [errorStateMatcher]="matchZip">
                     <mat-error *ngIf="customerFormGroup.controls.zip.hasError('required')">
                         Zip is <strong>required</strong>
                     </mat-error>
@@ -158,7 +158,7 @@
                             <div class="d-flex flex-column mr-2 w-50" [formGroup]="contactFormGroup">
                                 <mat-form-field appearance="outline">
                                     <mat-label>First Name*</mat-label>
-                                    <input type="text" matInput placeholder="First Name" formControlName="firstName"
+                                    <input type="text" trim="blur" matInput placeholder="First Name" formControlName="firstName"
                                         [errorStateMatcher]="matchFirstName">
                                     <mat-error *ngIf="contactFormGroup.controls.firstName.hasError('required')">
                                         First name <strong>required</strong>
@@ -168,7 +168,7 @@
                             <div class="d-flex flex-column mr-2 w-50" [formGroup]="contactFormGroup">
                                 <mat-form-field appearance="outline">
                                     <mat-label>Last Name*</mat-label>
-                                    <input type="text" matInput placeholder="Last Name" formControlName="lastName"
+                                    <input type="text" trim="blur" matInput placeholder="Last Name" formControlName="lastName"
                                         [errorStateMatcher]="matchLastName">
                                     <mat-error *ngIf="contactFormGroup.controls.lastName.hasError('required')">
                                         Last name <strong>required</strong>
@@ -180,20 +180,20 @@
                             <div class="d-flex flex-column mr-2 w-50" [formGroup]="contactFormGroup">
                                 <mat-form-field appearance="outline">
                                     <mat-label>Title</mat-label>
-                                    <input type="text" matInput placeholder="Title" formControlName="title">
+                                    <input type="text" trim="blur" matInput placeholder="Title" formControlName="title">
                                 </mat-form-field>
                             </div>
                             <div class="d-flex flex-column mr-2 w-50" [formGroup]="contactFormGroup">
                                 <mat-form-field appearance="outline">
                                     <mat-label>Office Phone</mat-label>
-                                    <input type="text" matInput placeholder="Office Phone"
+                                    <input type="text" trim="blur" matInput placeholder="Office Phone"
                                         formControlName="office_phone">
                                 </mat-form-field>
                             </div>
                             <div class="d-flex flex-column mr-2 w-50" [formGroup]="contactFormGroup">
                                 <mat-form-field appearance="outline">
                                     <mat-label>Mobile Phone</mat-label>
-                                    <input type="text" matInput placeholder="Mobile Phone"
+                                    <input type="text" trim="blur" matInput placeholder="Mobile Phone"
                                         formControlName="mobile_phone">
                                 </mat-form-field>
                             </div>
@@ -202,7 +202,7 @@
                             <div class="d-flex flex-column mr-2 w-100" [formGroup]="contactFormGroup">
                                 <mat-form-field appearance="outline">
                                     <mat-label>Email*</mat-label>
-                                    <input type="text" matInput placeholder="Email" formControlName="email"
+                                    <input type="text" trim="blur" matInput placeholder="Email" formControlName="email"
                                         [errorStateMatcher]="matchEmail">
                                     <mat-error *ngIf="contactFormGroup.controls.email.hasError('required')">
                                         Email <strong>required</strong>
@@ -217,7 +217,7 @@
                         <div class="d-flex flex-row flex-grow-1 w-100" [formGroup]="contactFormGroup">
                             <mat-form-field appearance="outline" class="flex-grow-1">
                                 <mat-label>Contact Notes</mat-label>
-                                <textarea matInput formControlName="contactNotes"></textarea>
+                                <textarea matInput trim="blur" formControlName="contactNotes"></textarea>
                             </mat-form-field>
                         </div>
                         <div class="d-flex flex-row flex-grow-1">

--- a/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.ts
+++ b/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.ts
@@ -60,13 +60,13 @@ export class AddCustomerComponent implements OnInit, OnDestroy {
   matchEmail = new MyErrorStateMatcher();
 
   customerFormGroup = new FormGroup({
-    customerName: new FormControl('', [Validators.required, this.notJustSpaces]),
-    customerIdentifier: new FormControl('', [Validators.required, this.notJustSpaces]),
-    address1: new FormControl('', [Validators.required, this.notJustSpaces]),
+    customerName: new FormControl('', [Validators.required]),
+    customerIdentifier: new FormControl('', [Validators.required]),
+    address1: new FormControl('', [Validators.required]),
     address2: new FormControl(''),
-    city: new FormControl('', [Validators.required, this.notJustSpaces]),
-    state: new FormControl('', [Validators.required, this.notJustSpaces]),
-    zip: new FormControl('', [Validators.required, this.notJustSpaces]),
+    city: new FormControl('', [Validators.required]),
+    state: new FormControl('', [Validators.required]),
+    zip: new FormControl('', [Validators.required]),
     sector: new FormControl(null),
     industry: new FormControl(null),
     customerType: new FormControl('', [Validators.required])
@@ -404,19 +404,5 @@ export class AddCustomerComponent implements OnInit, OnDestroy {
 
   customerValid() {
     return this.customerFormGroup.valid && this.contacts.data.length > 0;
-  }
-
-  /**
-   * A validator that allows an empty control, but does not allow
-   * only spaces.
-   */
-  notJustSpaces(control: FormControl) {
-    // allow an empty field
-    if (control.value === '') {
-      return null;
-    }
-    const isWhitespace = (control.value || '').trim().length === 0;
-    const isValid = !isWhitespace;
-    return isValid ? null : { whitespace: true };
   }
 }

--- a/client/AdminUI/src/app/components/subscriptions/manage-subscription/manage-subscription.component.html
+++ b/client/AdminUI/src/app/components/subscriptions/manage-subscription/manage-subscription.component.html
@@ -92,7 +92,7 @@
                 to prioritize phishing emails relevant to their industry.
             </div>
             <mat-form-field class="w-100" appearance="outline">
-                <input matInput formControlName="url" type="text"
+                <input matInput formControlName="url" type="text" trim="blur"
                     [ngClass]="{ 'is-invalid': submitted && f.url.errors }">
                 <mat-error *ngIf="submitted && f.url.errors?.whitespace" class="invalid-feedback">
                     Customer Website may not contain only spaces
@@ -105,7 +105,7 @@
                 They will be used to select applicable templates.</div>
             <mat-form-field class="w-100" appearance="outline">
                 <mat-label>Applicability Word Tags</mat-label>
-                <textarea matInput autosize formControlName="keywords"></textarea>
+                <textarea matInput trim="blur" autosize formControlName="keywords"></textarea>
                 <mat-error *ngIf="submitted && f.keywords.errors?.whitespace" class="invalid-feedback">
                     Keywords may not contain only spaces
                 </mat-error>

--- a/client/AdminUI/src/app/components/subscriptions/manage-subscription/manage-subscription.component.ts
+++ b/client/AdminUI/src/app/components/subscriptions/manage-subscription/manage-subscription.component.ts
@@ -99,12 +99,8 @@ export class ManageSubscriptionComponent implements OnInit, OnDestroy {
       startDate: new FormControl(new Date(), {
         validators: Validators.required
       }),
-      url: new FormControl('', {
-        validators: this.notJustSpaces
-      }),
-      keywords: new FormControl('', {
-        validators: this.notJustSpaces
-      }),
+      url: new FormControl('', {}),
+      keywords: new FormControl('', {}),
       sendingProfile: new FormControl('', {
         validators: Validators.required
       }),
@@ -145,11 +141,11 @@ export class ManageSubscriptionComponent implements OnInit, OnDestroy {
       this.persistChanges();
     });
     this.f.url.valueChanges.subscribe(val => {
-      this.subscription.url = val.trim();
+      this.subscription.url = val; // val.trim();
       this.persistChanges();
     });
     this.f.keywords.valueChanges.subscribe(val => {
-      this.subscription.keywords = val.trim();
+      this.subscription.keywords = val; // val.trim();
       this.persistChanges();
     });
     this.f.sendingProfile.valueChanges.subscribe(val => {
@@ -604,10 +600,10 @@ export class ManageSubscriptionComponent implements OnInit, OnDestroy {
     sub.url = this.f.url.value;
 
     // keywords
-    sub.keywords = this.f.keywords.value.trim();
+    sub.keywords = this.f.keywords.value;
 
     // set the target list
-    const csv = this.f.csvText.value.trim();
+    const csv = this.f.csvText.value;
     sub.target_email_list = this.buildTargetsFromCSV(csv);
 
     sub.sending_profile_name = this.f.sendingProfile.value;
@@ -683,7 +679,7 @@ export class ManageSubscriptionComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const lines = csv.split('\n');
+    const lines = csv.trim().split('\n');
     lines.forEach((line: string) => {
       const parts = line.split(',');
       while (parts.length < 4) {
@@ -778,20 +774,6 @@ export class ManageSubscriptionComponent implements OnInit, OnDestroy {
     window.open(url, "_blank");
   }
   */
-
-  /**
-   * A validator that allows an empty control, but does not allow
-   * only spaces.
-   */
-  notJustSpaces(control: FormControl) {
-    // allow an empty field
-    if (control.value === '') {
-      return null;
-    }
-    const isWhitespace = (control.value || '').trim().length === 0;
-    const isValid = !isWhitespace;
-    return isValid ? null : { whitespace: true };
-  }
 
   /**
    * A validator that requires the csv field to contain certain elements on each row

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -29,7 +29,7 @@
       <div #selectedTemplateTitle class="flex-container flex-row selected-template">
         <mat-form-field class="w-100 selected_template_title" appearance="outline">
           <mat-label>Template Name</mat-label>
-          <input formControlName="templateName" matInput placeholder="Enter a template name" [errorStateMatcher]="matchTemplateName" />
+          <input formControlName="templateName" trim="blur" matInput placeholder="Enter a template name" [errorStateMatcher]="matchTemplateName" />
           <mat-error *ngIf=" 
               currentTemplateFormGroup.controls.templateName.hasError(
                 'required'
@@ -100,7 +100,7 @@
               <div class="d-flex flex-column pb-3">
                 <mat-form-field appearance="outline">
                   <mat-label>Subject*</mat-label>
-                  <input type="text" matInput placeholder="Template Subject" formControlName="templateSubject" [errorStateMatcher]="matchSubject" />
+                  <input type="text" trim="blur" matInput placeholder="Template Subject" formControlName="templateSubject" [errorStateMatcher]="matchSubject" />
                   <mat-error *ngIf="
                       currentTemplateFormGroup.controls.templateSubject.hasError(
                         'required'
@@ -116,7 +116,7 @@
               <div class="d-flex flex-column pb-3">
                 <mat-form-field appearance="outline">
                   <mat-label>From Address*</mat-label>
-                  <input type="text" matInput placeholder="Example@user.com" formControlName="templateFromAddress" [errorStateMatcher]="matchFromAddress" />
+                  <input type="text" trim="blur" matInput placeholder="Example@user.com" formControlName="templateFromAddress" [errorStateMatcher]="matchFromAddress" />
                   <mat-error *ngIf="
                       currentTemplateFormGroup.controls.templateFromAddress.hasError(
                         'required'
@@ -132,13 +132,13 @@
               <div class="d-flex flex-column pb-3">
                 <mat-form-field appearance="outline">
                   <mat-label>Description</mat-label>
-                  <input type="text" matInput placeholder="Template Description..." formControlName="templateDescription" />
+                  <input type="text" trim="blur" matInput placeholder="Template Description..." formControlName="templateDescription" />
                 </mat-form-field>
               </div>
               <div class="d-flex flex-column pb-3">
                 <mat-form-field appearance="outline" class="flex-grow-1">
                   <mat-label>Descriptive Words (CSV)</mat-label>
-                  <textarea matInput cdkTextareaAutosize cdkAutosizeMinRows="5" cdkAutosizeMaxRows="10" placeholder="Template Descriptive Words Seperated By A Comma" formControlName="templateDescriptiveWords"></textarea>
+                  <textarea trim="blur" matInput cdkTextareaAutosize cdkAutosizeMinRows="5" cdkAutosizeMaxRows="10" placeholder="Template Descriptive Words Seperated By A Comma" formControlName="templateDescriptiveWords"></textarea>
                 </mat-form-field>
               </div>
 
@@ -293,7 +293,7 @@
         <div class="d-flex flex-row">
           <mat-form-field appearance="outline" class="flex-grow-1">
             <mat-label>Final Deception Score</mat-label>
-            <input type="text" matInput placeholder="DeceptionScore" formControlName="final_deception_score">
+            <input type="text" trim="blur" matInput placeholder="DeceptionScore" formControlName="final_deception_score">
           </mat-form-field>
         </div>
 

--- a/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/client/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -183,16 +183,15 @@ export class TemplateManagerComponent implements OnInit {
 
     this.currentTemplateFormGroup = new FormGroup({
       templateUUID: new FormControl(template.template_uuid),
-      templateName: new FormControl(template.name, [Validators.required, this.notJustSpaces]),
+      templateName: new FormControl(template.name, [Validators.required]),
       templateDeceptionScore: new FormControl(template.deception_score),
       templateDescriptiveWords: new FormControl(template.descriptive_words),
       templateDescription: new FormControl(template.description),
       templateFromAddress: new FormControl(template.from_address, [
-        Validators.required, this.notJustSpaces
-      ]),
-      templateSubject: new FormControl(template.subject, [Validators.required, this.notJustSpaces]),
+        Validators.required]),
+      templateSubject: new FormControl(template.subject, [Validators.required]),
       templateText: new FormControl(template.text),
-      templateHTML: new FormControl(template.html, [Validators.required, this.notJustSpaces]),
+      templateHTML: new FormControl(template.html, [Validators.required]),
       authoritative: new FormControl(template.sender?.authoritative ?? 0),
       external: new FormControl(template.sender?.external ?? 0),
       internal: new FormControl(template.sender?.internal ?? 0),
@@ -569,18 +568,5 @@ export class TemplateManagerComponent implements OnInit {
   insertTag(selection, tagText: string) {
     const newNode = document.createTextNode(tagText);
     selection.insertNode(newNode);
-  }
-
-  /**
-   * 
-   */
-  notJustSpaces(control: FormControl) {
-    // allow an empty field
-    if (control.value === '' || control.value === null) {
-      return null;
-    }
-    const isWhitespace = (control.value || '').trim().length === 0;
-    const isValid = !isWhitespace;
-    return isValid ? null : { whitespace: true };
   }
 }

--- a/client/AdminUI/src/app/helper/input-trim.directive.ts
+++ b/client/AdminUI/src/app/helper/input-trim.directive.ts
@@ -1,0 +1,160 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  Inject,
+  Input,
+  Optional,
+  Renderer2
+} from '@angular/core';
+import {
+  COMPOSITION_BUFFER_MODE,
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR
+} from '@angular/forms';
+
+@Directive({
+  selector: 'input[trim], textarea[trim]',
+  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: InputTrimDirective, multi: true }]
+})
+export class InputTrimDirective implements ControlValueAccessor {
+
+  private get _type(): string {
+    return this._sourceElementRef.nativeElement.type || 'text';
+  }
+
+  // Get a value of the trim attribute if it was set.
+  @Input() trim: string;
+
+  /**
+   * Keep the value of input element in a cache.
+   *
+   * @type {string}
+   * @private
+   */
+  private _value: string;
+
+  // Source services to modify elements.
+  private _sourceRenderer: Renderer2;
+  private _sourceElementRef: ElementRef;
+
+  /**
+   * Updates the value on the blur event.
+   */
+  @HostListener('blur', ['$event.type', '$event.target.value'])
+  onBlur(event: string, value: string): void {
+    this.updateValue(event, value.trim());
+    this.onTouched();
+  }
+
+  /**
+   * Updates the value on the input event.
+   */
+  @HostListener('input', ['$event.type', '$event.target.value'])
+  onInput(event: string, value: string): void {
+    this.updateValue(event, value);
+  }
+
+  onChange = (_: any) => { };
+
+  onTouched = () => { };
+
+  constructor(
+    @Inject(Renderer2) renderer: Renderer2,
+    @Inject(ElementRef) elementRef: ElementRef,
+    @Optional() @Inject(COMPOSITION_BUFFER_MODE) compositionMode: boolean
+  ) {
+    this._sourceRenderer = renderer;
+    this._sourceElementRef = elementRef;
+  }
+
+  registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }
+
+  registerOnTouched(fn: () => void): void { this.onTouched = fn; }
+
+  /**
+   * Writes a new value to the element based on the type of input element.
+   *
+   * @param {any} value - new value
+   */
+  public writeValue(value: any): void {
+    //
+    // The Template Driven Form doesn't automatically convert undefined values to null. We will do,
+    // keeping an empty string as string because the condition `'' || null` returns null what
+    // could change the initial state of a model.
+    // The Reactive Form does it automatically during initialization.
+    //
+    // SEE: https://github.com/anein/angular2-trim-directive/issues/18
+    //
+    this._value = value === '' ? '' : value || null;
+
+    this._sourceRenderer.setProperty(this._sourceElementRef.nativeElement, 'value', this._value);
+
+    // a dirty trick (or magic) goes here:
+    // it updates the element value if `setProperty` doesn't set a new value for some reason.
+    //
+    // SEE: https://github.com/anein/angular2-trim-directive/issues/9
+    //
+    if (this._type !== 'text') {
+      this._sourceRenderer.setAttribute(this._sourceElementRef.nativeElement, 'value', this._value);
+    }
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._sourceRenderer.setProperty(this._sourceElementRef.nativeElement, 'disabled', isDisabled);
+  }
+
+  /**
+   * Writes the cursor position in safari
+   *
+   * @param cursorPosition - the cursor current position
+   * @param hasTypedSymbol
+   */
+  private setCursorPointer(cursorPosition: any, hasTypedSymbol: boolean): void {
+    // move the cursor to the stored position (Safari usually moves the cursor to the end)
+    // setSelectionRange method apply only to inputs of types text, search, URL, tel and password
+    if (hasTypedSymbol && ['text', 'search', 'url', 'tel', 'password'].indexOf(this._type) >= 0) {
+      // Ok, for some reason in the tests the type changed is not being catch and because of that
+      // this line is executed and causes an error of DOMException, it pass the text without problem
+      // But it should be a better way to validate that type change
+      this._sourceElementRef.nativeElement.setSelectionRange(cursorPosition, cursorPosition);
+    }
+  }
+
+  /**
+   * Trims an input value, and sets it to the model and element.
+   *
+   * @param {string} value - input value
+   * @param {string} event - input event
+   */
+  private updateValue(event: string, value: string): void {
+    // check if the user has set an optional attribute, and Trimmmm!!! Uhahahaha!
+    value = this.trim !== '' && event !== this.trim ? value : value.trim();
+
+    const previous = this._value;
+
+    // store the cursor position
+    const cursorPosition = this._sourceElementRef.nativeElement.selectionStart;
+
+    // write value to the element.
+    this.writeValue(value);
+
+    // Update the model only on getting new value, and prevent firing
+    // the `dirty` state when click on empty fields.
+    //
+    // SEE:
+    //    https://github.com/anein/angular2-trim-directive/issues/17
+    //    https://github.com/anein/angular2-trim-directive/issues/35
+    //    https://github.com/anein/angular2-trim-directive/issues/39
+    //
+    if ((this._value || previous) && this._value.trim() !== previous) {
+      this.onChange(this._value);
+    }
+
+    // check that non-null value is being changed
+    const hasTypedSymbol = value && previous && value !== previous;
+
+    // write the cursor position
+    this.setCursorPointer(cursorPosition, hasTypedSymbol);
+  }
+}


### PR DESCRIPTION
# Reworked how input fields are trimmed before validation.

## 🗣 Description

Fields now trim themselves on blur.  This prevents leading and trailing spaces from being saved in the database, and also allows 'required' validators to do their thing if the user just enters spaces in a required field.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
