### PR TITLE
Bug Fix 354 - Fixed the removal of duplicate target emails on an active subscription

### DIFF
--- a/client/AdminUI/src/app/components/subscriptions/manage-subscription/manage-subscription.component.ts
+++ b/client/AdminUI/src/app/components/subscriptions/manage-subscription/manage-subscription.component.ts
@@ -695,7 +695,9 @@ export class ManageSubscriptionComponent implements OnInit, OnDestroy {
     });
 
     // remove duplicate emails if desired
-    if (this.subscriptionSvc.removeDupeTargets) {
+    const status = this.subscription?.status?.toLowerCase();
+    console.log(status)
+    if (this.subscriptionSvc.removeDupeTargets && status != "in progress") {
       const uniqueArray: Target[] = targetList.filter((t1, index) => {
         return (
           index ===

--- a/controller/src/scripts/data/templates.json
+++ b/controller/src/scripts/data/templates.json
@@ -1497,7 +1497,7 @@
     "name": "Workflows Update",
     "template_type": "Email",
     "complexity": 5,
-    "html": "<br>All,<br><br>Our organization's website is being upgraded to the newest applications package. This<br>change, however, will affect how we use the current Workflows app. Before<br>these changes are made, we need everyone to complete our survey on<br><%DOMAIN%>(under the Survey tab) to determine who uses the<br>Work Flows and what processes will be impacted (even if you don't use it,<br>we still need your \"No\" response cataloged). Please visit our Wiki<br><a href=\"<%URL%>\">https://><%DOMAIN%>/ITDeployment/wiki</a> to read the FAQ and track all other updates.<br><br>Thanks,<br><%SPOOF_NAME_FULL%>, IT Deployment Team<br>Information Technology Operations<br>Office of the Chief Information Officer<br>",
+    "html": "<br>All,<br><br>Our organization's website is being upgraded to the newest applications package. This<br>change, however, will affect how we use the current Workflows app. Before<br>these changes are made, we need everyone to complete our survey on<br><%DOMAIN%>(under the Survey tab) to determine who uses the<br>Work Flows and what processes will be impacted (even if you don't use it,<br>we still need your \"No\" response cataloged). Please visit our Wiki<br><a href=\"<%URL%>\">https://<%DOMAIN%>/ITDeployment/wiki</a> to read the FAQ and track all other updates.<br><br>Thanks,<br><%SPOOF_NAME_FULL%>, IT Deployment Team<br>Information Technology Operations<br>Office of the Chief Information Officer<br>",
     "behavior": {
       "duty_obligation": 1,
       "fear": 0,


### PR DESCRIPTION
## 🗣 Description
Added logic to prevent the removal of duplicate emails on an active subscription. The repeated patch requests that are called from the on change values being triggered on form initialization were causing the logic for target email duplication to be triggered.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
