### PR TITLE
Fix for CPA-370-BUG, subscription primary contact changes not persisting

### DIFF
--- a/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
+++ b/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
@@ -226,7 +226,7 @@
                             </div>
                         </div>
                         <button mat-raised-button color="primary" *ngIf="!isEdit" (click)="pushContact()"
-                            [disabled]="!contactFormGroup.valid">Add</button>
+                            [disabled]="!contactFormGroup.valid">Add testbutton</button>
                         <button mat-raised-button color="primary" *ngIf="isEdit" (click)="pushContact()"
                             [disabled]="!contactFormGroup.valid">Edit</button>
                         <button mat-flat-button (click)="showAddContact(false)">Close</button>

--- a/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.ts
+++ b/client/AdminUI/src/app/components/customer/add-customer/add-customer.component.ts
@@ -20,6 +20,7 @@ import {
 import { MatTableDataSource } from '@angular/material/table';
 import { LayoutMainService } from 'src/app/services/layout-main.service';
 import { Subscription } from 'rxjs';
+import { isString } from 'util';
 
 @Component({
   selector: 'app-add-customer',
@@ -292,28 +293,45 @@ export class AddCustomerComponent implements OnInit, OnDestroy {
 
   pushContact() {
     if (this.contactFormGroup.valid) {
-      if (this.isEdit) {
-        this.removeContact(this.tempEditContact);
-        this.tempEditContact = null;
-        this.isEdit = false;
+      let isNotDuplicateEmail = true 
+      let duplicateEmailName = ""
+      //Check for existing contact with the same email
+      this.contacts.data.forEach(element => {
+        console.log("Checking emails")
+        if(element.email.toLocaleLowerCase() == String(this.contactFormGroup.controls['email'].value).toLocaleLowerCase() ){
+          console.log("SET FORM CONTROL INVALID HERE, EMAILS DUPLICATED")
+          isNotDuplicateEmail = false
+          duplicateEmailName = element.first_name + " " + element.last_name
+        }
+      });
+      if(isNotDuplicateEmail){
+        if (this.isEdit) {
+          this.removeContact(this.tempEditContact);
+          this.tempEditContact = null;
+          this.isEdit = false;
+        }
+        const contact: Contact = {
+          office_phone: this.contactFormGroup.controls['office_phone'].value,
+          mobile_phone: this.contactFormGroup.controls['mobile_phone'].value,
+          email: this.contactFormGroup.controls['email'].value,
+          first_name: this.contactFormGroup.controls['firstName'].value,
+          last_name: this.contactFormGroup.controls['lastName'].value,
+          title: this.contactFormGroup.controls['title'].value,
+          notes: this.contactFormGroup.controls['contactNotes'].value,
+          active: true
+        };
+        const previousContacts = this.contacts.data;
+        
+        previousContacts.push(contact);
+        this.contacts.data = previousContacts;
+        this.clearContact();
+      } else {
+        this.contactError = "A contact with this email already exists : " + duplicateEmailName
       }
-      const contact: Contact = {
-        office_phone: this.contactFormGroup.controls['office_phone'].value,
-        mobile_phone: this.contactFormGroup.controls['mobile_phone'].value,
-        email: this.contactFormGroup.controls['email'].value,
-        first_name: this.contactFormGroup.controls['firstName'].value,
-        last_name: this.contactFormGroup.controls['lastName'].value,
-        title: this.contactFormGroup.controls['title'].value,
-        notes: this.contactFormGroup.controls['contactNotes'].value,
-        active: true
-      };
-      const previousContacts = this.contacts.data;
-      previousContacts.push(contact);
-      this.contacts.data = previousContacts;
-      this.clearContact();
     } else {
       this.contactError = 'Fix required fields.';
     }
+    
   }
 
   editContact(contact: Contact) {

--- a/client/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
+++ b/client/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
@@ -34,7 +34,7 @@
         </mat-card-header>
 
         <mat-label class="h6">Override Value</mat-label>
-        <div class="text-muted">Entering this val will override the individual records below
+        <div class="text-muted">Entering a value here will override the individual records below
             and will cause the reporting to be incomplete when using reported times. Use only if 
             individual records can not be provided.
         </div>


### PR DESCRIPTION
## 🗣 Description

Primary contact value being determined by email value. If more than one primary contact for a customer had the same email, the first one would be selected, resulting in inconsistent behavior. 

Modified the customer creation to not allow for multiple contacts to have the same email.
## 💭 Motivation and Context

CPA-370, bug

## 🧪 Testing

Tested the creation of contacts. Tested assigning a subscriptions primary contact.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
