### PR TITLE
feature: utilize reports service from email service

### DIFF
--- a/client/ReportService/Dockerfile
+++ b/client/ReportService/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 COPY ./package.json ./
 COPY ./src .
 
-#
 RUN npm install
 
 COPY --chown=node:node . .

--- a/client/ReportService/src/app/generate_pdf.js
+++ b/client/ReportService/src/app/generate_pdf.js
@@ -30,8 +30,10 @@ module.exports = {
     //GRR how do we deal with this api configuration. 
     //I'm not pleased with the idea of putting it in the .env.
     //this should not have to be configured it should be determined
-
-    const reportUrl = "http://pca-web:4200/reports/monthly/dacf7576-6fc8-4a06-bf61-0dc90993c30e/2020-07-17";
+    const uuid = req.params.subscriptionUUID
+    const type = req.params.type
+    const reportUrl = `http://pca-web:4200/reports/${type}/${uuid}/2020-07-17`;
+    console.log(reportUrl)
     const pdfContent = await convertToPDf(reportUrl);
     //res.contentType("application/pdf");
     res.setHeader("Content-Type", "application/pdf");

--- a/client/ReportService/src/app/generate_pdf.js
+++ b/client/ReportService/src/app/generate_pdf.js
@@ -35,7 +35,7 @@ module.exports = {
     const cycle = req.params.cycle
 
     const reportUrl = `http://pca-web:4200/reports/${type}/${uuid}/${cycle}`;
-    console.log(reportUrl)
+
     const pdfContent = await convertToPDf(reportUrl);
     //res.contentType("application/pdf");
     res.setHeader("Content-Type", "application/pdf");

--- a/client/ReportService/src/app/generate_pdf.js
+++ b/client/ReportService/src/app/generate_pdf.js
@@ -32,7 +32,9 @@ module.exports = {
     //this should not have to be configured it should be determined
     const uuid = req.params.subscriptionUUID
     const type = req.params.type
-    const reportUrl = `http://pca-web:4200/reports/${type}/${uuid}/2020-07-17`;
+    const cycle = req.params.cycle
+
+    const reportUrl = `http://pca-web:4200/reports/${type}/${uuid}/${cycle}`;
     console.log(reportUrl)
     const pdfContent = await convertToPDf(reportUrl);
     //res.contentType("application/pdf");

--- a/client/ReportService/src/app/generate_pdf.js
+++ b/client/ReportService/src/app/generate_pdf.js
@@ -6,10 +6,10 @@ let convertToPDf = async (reportUrl) => {
   const page = await browser.newPage();
   await page.goto(reportUrl, { waitUntil: 'networkidle2' });
   await page.emulateMediaType('screen');
-  const pdfContent = await page.pdf({ 
+  const pdfContent = await page.pdf({
     format: 'Letter',
     printBackground: true
-   });
+  });
 
 
   // res.on(, function(chunk) {
@@ -31,7 +31,7 @@ module.exports = {
     //I'm not pleased with the idea of putting it in the .env.
     //this should not have to be configured it should be determined
 
-    const reportUrl = "http://pca-web:4200/reports/monthly/d89a72b0-254f-40fb-a37c-6e6654cd5265/2020-08-17";
+    const reportUrl = "http://pca-web:4200/reports/monthly/dacf7576-6fc8-4a06-bf61-0dc90993c30e/2020-07-17";
     const pdfContent = await convertToPDf(reportUrl);
     //res.contentType("application/pdf");
     res.setHeader("Content-Type", "application/pdf");

--- a/client/ReportService/src/app/routes.js
+++ b/client/ReportService/src/app/routes.js
@@ -1,10 +1,10 @@
 var pdf = require('./generate_pdf')
 
-class ReportRequest{
-	subscription_uuid; 
+class ReportRequest {
+	subscription_uuid;
 	start_date;
 	report_type;
-	constructor(u,s,r){
+	constructor(u, s, r) {
 		this.report_type = r;
 		this.start_date = s;
 		this.subscription_uuid = u;
@@ -12,16 +12,14 @@ class ReportRequest{
 };
 
 
-module.exports = function(app) {
-	app.get('/api/reportpdf', function(req, res) {
-		
-		//_id : req.params.subscription_uuid;
-		pdf.PdfReportUrl(req, res);				
+module.exports = function (app) {
+	app.get('/api/:type/:subscriptionUUID/pdf/', function (req, res) {
+		pdf.PdfReportUrl(req, res);
 		//res.json(new ReportRequest("uuid","startdate","Monthly")); // return all todos in JSON format		
 	});
 
 	// application -------------------------------------------------------------
-	app.get('*', function(req, res) {
+	app.get('*', function (req, res) {
 		res.sendfile('./public/index.html'); // load the single view file (angular will handle the page changes on the front-end)
 	});
 };

--- a/client/ReportService/src/app/routes.js
+++ b/client/ReportService/src/app/routes.js
@@ -13,9 +13,8 @@ class ReportRequest {
 
 
 module.exports = function (app) {
-	app.get('/api/:type/:subscriptionUUID/pdf/', function (req, res) {
+	app.get('/api/:type/:subscriptionUUID/:cycle/pdf/', function (req, res) {
 		pdf.PdfReportUrl(req, res);
-		//res.json(new ReportRequest("uuid","startdate","Monthly")); // return all todos in JSON format		
 	});
 
 	// application -------------------------------------------------------------

--- a/controller/etc/env.dist
+++ b/controller/etc/env.dist
@@ -15,6 +15,9 @@ MONGO_INITDB_ROOT_PASSWORD=rootpassword
 MONGO_INITDB_ROOT_USERNAME=root
 MONGO_INITDB_DATABASE=pca_data_dev
 
+# Reports Service api
+REPORTS_API=pca-pdf-report:3030
+
 # GoPhish
 GP_URL=http://gophish:3333/
 PHISH_URL=http://gophish:8080/

--- a/controller/src/config/settings.py
+++ b/controller/src/config/settings.py
@@ -175,6 +175,9 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
 }
 
+# Reports Service API
+REPORTS_API = os.environ.get("REPORTS_API", "pca-pdf-report:3030")
+
 # GoPhish
 GP_URL = os.environ.get("GP_URL", "")
 GP_API_KEY = os.environ.get("GP_API_KEY", "")

--- a/controller/src/notifications/utils.py
+++ b/controller/src/notifications/utils.py
@@ -10,7 +10,7 @@ def get_notification(message_type):
     Parses out the type of notificartion.
     """
     if message_type == "monthly_report":
-        subject = "DHS CISA Phishing Subscription Monthly Report"
+        subject = "DHS CISA Phishing Subscription Status Report"
         path = "monthly_report"
         link = "monthly"
     elif message_type == "cycle_report":

--- a/controller/src/notifications/views.py
+++ b/controller/src/notifications/views.py
@@ -39,7 +39,7 @@ class ReportsEmailSender:
 
     def get_attachment(self, subscription_uuid, link):
         """Get_attachment method."""
-        url = f"http://{settings.REPORTS_API}/api/reportpdf"
+        url = f"http://{settings.REPORTS_API}/api/{link}/{subscription_uuid}/pdf/"
         resp = requests.get(url, stream=True)
         fs = FileSystemStorage("/tmp")
         filename = Path("/tmp/subscription_report.pdf")

--- a/controller/src/notifications/views.py
+++ b/controller/src/notifications/views.py
@@ -37,9 +37,11 @@ class ReportsEmailSender:
         self.subscription = subscription
         self.message_type = message_type
 
-    def get_attachment(self, subscription_uuid, link):
+    def get_attachment(self, subscription_uuid, link, cycle):
         """Get_attachment method."""
-        url = f"http://{settings.REPORTS_API}/api/{link}/{subscription_uuid}/pdf/"
+        url = (
+            f"http://{settings.REPORTS_API}/api/{link}/{subscription_uuid}/{cycle}/pdf/"
+        )
         resp = requests.get(url, stream=True)
         fs = FileSystemStorage("/tmp")
         filename = Path("/tmp/subscription_report.pdf")
@@ -91,7 +93,11 @@ class ReportsEmailSender:
         message.attach_alternative(html_content, "text/html")
 
         # add pdf attachment
-        attachment = self.get_attachment(subscription_uuid, link)
+        current_cycle = self.subscription.get("cycles")[-1]
+        cycle_date = datetime.strftime(
+            current_cycle.get("start_date"), format="%Y-%m-%d"
+        )
+        attachment = self.get_attachment(subscription_uuid, link, cycle_date)
         message.attach("subscription_report.pdf", attachment.read(), "application/pdf")
         try:
             message.send(fail_silently=False)

--- a/controller/src/notifications/views.py
+++ b/controller/src/notifications/views.py
@@ -12,6 +12,7 @@ from email.mime.image import MIMEImage
 import logging
 
 # Third-Party Libraries
+from django.conf import settings
 from pathlib import Path
 import requests
 from api.models.dhs_models import DHSContactModel, validate_dhs_contact
@@ -23,6 +24,7 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from notifications.utils import get_notification
 from weasyprint import HTML
+
 
 logger = logging.getLogger()
 
@@ -37,7 +39,7 @@ class ReportsEmailSender:
 
     def get_attachment(self, subscription_uuid, link):
         """Get_attachment method."""
-        url = "http://pca-pdf-report:3030/api/reportpdf"
+        url = f"http://{settings.REPORTS_API}/api/reportpdf"
         resp = requests.get(url, stream=True)
         fs = FileSystemStorage("/tmp")
         filename = Path("/tmp/subscription_report.pdf")

--- a/controller/src/notifications/views.py
+++ b/controller/src/notifications/views.py
@@ -12,9 +12,8 @@ from email.mime.image import MIMEImage
 import logging
 
 # Third-Party Libraries
-# Local Libraries
-# Django Libraries
-# Local Libraries
+from pathlib import Path
+import requests
 from api.models.dhs_models import DHSContactModel, validate_dhs_contact
 from api.utils.db_utils import get_single
 from django.conf import settings
@@ -38,9 +37,11 @@ class ReportsEmailSender:
 
     def get_attachment(self, subscription_uuid, link):
         """Get_attachment method."""
-        html = HTML(f"http://localhost:8000/reports/{subscription_uuid}/{link}/")
-        html.write_pdf("/tmp/subscription_report.pdf")
+        url = "http://pca-pdf-report:3030/api/reportpdf"
+        resp = requests.get(url, stream=True)
         fs = FileSystemStorage("/tmp")
+        filename = Path("/tmp/subscription_report.pdf")
+        filename.write_bytes(resp.content)
         return fs.open("subscription_report.pdf")
 
     def send(self):


### PR DESCRIPTION
Implement reports service into the backend email service

## 🗣 Description
Refactor the backend email service to utilize the new reports service for reports pdf attachments

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

Successfully sent live test emails with pdf attachments generated from the reports service

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
