### PR TITLE
add dns internal shared services record

### DIFF
--- a/cool/route53.tf
+++ b/cool/route53.tf
@@ -18,6 +18,20 @@ resource "aws_route53_record" "public" {
   }
 }
 
+resource "aws_route53_record" "sharedservices_internal" {
+  provider = aws.dns_sharedservices
+
+  zone_id = local.cool_dns_private_zone.zone_id
+  name    = var.hosted_zone_name
+  type    = "A"
+
+  alias {
+    name                   = module.public_alb.alb_dns_name
+    zone_id                = module.public_alb.alb_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "sharedservices_internal_web" {
   provider = aws.dns_sharedservices
 


### PR DESCRIPTION
Add a DNS internal shared service record to access gophish landing pages

## 🗣 Description ##

When on the VPN in the COOL and you run a subscription, when an email lands in your inbox, you can’t navigate to the landing page. I believe this is because the private DNS zone takes precedence over the public DNS zone, where the landing page records are. Probably can create a duplicate record in the internal DNS zone and this issue would be fixed

## 💭 Motivation and context ##
Fix access to landing pages


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [X] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
