### PR TITLE
Remove exports s3 bucket

### DIFF
--- a/cool/api.tf
+++ b/cool/api.tf
@@ -19,7 +19,6 @@ locals {
     "GP_URL" : "https://${aws_route53_record.sharedservices_internal_gophish.name}/"
     "WEBHOOK_URL" : "http://${aws_route53_record.sharedservices_internal_api.name}/api/v1/inboundwebhook/"
     "AWS_S3_IMAGE_BUCKET" : aws_s3_bucket.images.id
-    "AWS_S3_EXPORT_BUCKET" : aws_s3_bucket.exports.id
     "DEFAULT_FILE_STORAGE" : "storages.backends.s3boto3.S3Boto3Storage"
     "WORKERS" : var.api_gunicorn_workers
     "AWS_COGNITO_ENABLED": 1

--- a/cool/lambda.tf
+++ b/cool/lambda.tf
@@ -72,28 +72,6 @@ resource "aws_lambda_function" "queue_tasks" {
   }
 }
 
-resource "aws_lambda_function" "export" {
-  filename         = data.archive_file.code.output_path
-  function_name    = "${var.app}-${var.env}-export"
-  handler          = "lambda_functions.export.lambda_handler"
-  role             = aws_iam_role.lambda_exec_role.arn
-  memory_size      = var.tasks_memory
-  runtime          = "python3.8"
-  source_code_hash = data.archive_file.code.output_base64sha256
-  timeout          = var.tasks_timeout
-
-  layers = [aws_lambda_layer_version.layer.arn]
-
-  environment {
-    variables = local.api_environment
-  }
-
-  vpc_config {
-    subnet_ids         = local.private_subnet_ids
-    security_group_ids = [aws_security_group.api.id]
-  }
-}
-
 # ===================================
 # Cloudwatch Event rule
 # ===================================

--- a/cool/s3.tf
+++ b/cool/s3.tf
@@ -20,7 +20,3 @@ resource "aws_s3_bucket" "images" {
 POLICY
 }
 
-resource "aws_s3_bucket" "exports" {
-  bucket = "${var.app}-${var.env}-exports"
-  acl    = "private"
-}


### PR DESCRIPTION
## 🗣 Description ##

Remove the s3 exports bucket.

## 💭 Motivation and context ##

Downloading subscriptions has been moved to the api and no longer requires the exports bucket.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
