### PR TITLE
Add public http listener for landing pages

### DIFF
--- a/cool/gophish.tf
+++ b/cool/gophish.tf
@@ -194,6 +194,17 @@ resource "aws_lb_listener" "landing" {
   }
 }
 
+resource "aws_lb_listener" "landing_http" {
+  load_balancer_arn = module.public_alb.alb_arn
+  port              = 80
+  protocol          = "HTTP"
+  
+  default_action {
+    target_group_arn = aws_lb_target_group.landing.arn
+    type             = "forward"
+  }
+}
+
 # ===========================
 # CONTAINER DEFINITION
 # ===========================


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Adding a public http listener so we can serve open tracking without using a redirect.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
We believe by using redirects for open tracking, it causing some opens not to be tracked.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
