### PR TITLE
hot fix: update landing page matcher

### DIFF
--- a/sandbox/api_lb.tf
+++ b/sandbox/api_lb.tf
@@ -29,7 +29,7 @@ resource "aws_lb_target_group" "landing" {
   health_check {
     healthy_threshold   = 3
     interval            = 60
-    matcher             = "404"
+    matcher             = "200"
     path                = "/"
     port                = local.landing_container_port
     protocol            = local.landing_container_protocol


### PR DESCRIPTION
Update landing page matcher from `404` to `200`

## 💭 Motivation and context ##
landing page health check was looking for a `404` status code as the landing page api didn't have at its' root url
It was recently updated to have return a 200 at the root url with a status message, however this change was missed.

## 🧪 Testing ##
testing on deployment

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
